### PR TITLE
Add vendor binaries to version info

### DIFF
--- a/spec/Packagist/Api/Result/Package/Version.php
+++ b/spec/Packagist/Api/Result/Package/Version.php
@@ -31,6 +31,7 @@ class Version extends ObjectBehavior
             'extra'              => array('symfony-app-dir' => 'sylius'),
             'require'            => array('php' => '>=5.4'),
             'require-dev'        => array('phpspec/phpspec2' => 'dev-develop'),
+            'bin'                => array('bin/sylius'),
         ));
     }
 
@@ -122,5 +123,10 @@ class Version extends ObjectBehavior
     function it_gets_require_dev()
     {
         $this->getRequireDev()->shouldReturn(array('phpspec/phpspec2' => 'dev-develop'));
+    }
+
+    function it_gets_bin()
+    {
+        $this->getBin()->shouldReturn(array('bin/sylius'));
     }
 }

--- a/src/Packagist/Api/Result/Package/Version.php
+++ b/src/Packagist/Api/Result/Package/Version.php
@@ -21,6 +21,7 @@ class Version extends AbstractResult
     protected $extra;
     protected $require;
     protected $requireDev;
+    protected $bin;
 
     public function getName()
     {
@@ -100,5 +101,10 @@ class Version extends AbstractResult
     public function getRequireDev()
     {
         return $this->requireDev;
+    }
+
+    public function getBin()
+    {
+        return $this->bin;
     }
 }


### PR DESCRIPTION
This _very_ simple patch adds access to vendor binaries listed in packagist's version info.
See http://getcomposer.org/doc/articles/vendor-binaries.md for details and e.g. https://packagist.org/packages/clue/phar-composer.json as an example.
