### PR TITLE
Correct 'faves' to 'favers'

### DIFF
--- a/spec/Packagist/Api/Result/Result.php
+++ b/spec/Packagist/Api/Result/Result.php
@@ -13,7 +13,7 @@ class Result extends ObjectBehavior
             'description' => 'Modern ecommerce for Symfony2',
             'url'         => 'http://sylius.com',
             'downloads'   => 999999999,
-            'faves'       => 999999999,
+            'favers'       => 999999999,
         ));
     }
 

--- a/src/Packagist/Api/Result/Result.php
+++ b/src/Packagist/Api/Result/Result.php
@@ -8,7 +8,7 @@ class Result extends AbstractResult
     protected $description;
     protected $url;
     protected $downloads;
-    protected $faves;
+    protected $favers;
 
     public function getName()
     {
@@ -32,6 +32,6 @@ class Result extends AbstractResult
 
     public function getFavers()
     {
-        return $this->faves;
+        return $this->favers;
     }
 }


### PR DESCRIPTION
The API doesn't retrieve the 'favers' property in the search API because it's incorrectly looking for 'faves'.