### PR TITLE
Update guzzle dependency to guzzle 5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ php:
   - 5.6
   - hhvm
 
+matrix:
+    allow_failures:
+        - php: 5.3
+
 before_script:
   - composer install --dev
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "guzzle/guzzle": "~3.0",
+        "guzzlehttp/guzzle": "~5.0",
         "doctrine/inflector": "~1.0"
     },
     "require-dev": {

--- a/spec/Packagist/Api/ClientSpec.php
+++ b/spec/Packagist/Api/ClientSpec.php
@@ -47,7 +47,7 @@ class ClientSpec extends ObjectBehavior
 
     function it_gets_popular_packages(HttpClient $client, Factory $factory, Request $request, Response $response)
     {
-        $client->get('https://packagist.org/explore/popular.json?page=1')->shouldBeCalled()->willReturn($request);
+        $client->get('https://packagist.org/explore/popular.json?page=1')->shouldBeCalled()->willReturn($response);
         $data = file_get_contents('spec/Packagist/Api/Fixture/popular.json');
         $response->getBody(true)->shouldBeCalled()->willReturn($data);
         $factory->create(json_decode($data, true))->shouldBeCalled()->willReturn(array_pad(array(), 5, null));

--- a/spec/Packagist/Api/ClientSpec.php
+++ b/spec/Packagist/Api/ClientSpec.php
@@ -7,9 +7,9 @@ use PhpSpec\Exception\Example\MatcherException;
 
 use Packagist\Api\Client;
 use Packagist\Api\Result\Factory;
-use Guzzle\Http\Message\Request;
-use Guzzle\Http\Message\Response;
-use Guzzle\Http\Client as HttpClient;
+use GuzzleHttp\Message\Request;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Client as HttpClient;
 
 class ClientSpec extends ObjectBehavior
 {
@@ -17,7 +17,7 @@ class ClientSpec extends ObjectBehavior
     {
         $this->beConstructedWith($client, $factory);
 
-        $request->send()->willReturn($response);
+        $client->send($request)->willReturn($response);
     }
 
     function it_is_initializable()
@@ -27,7 +27,7 @@ class ClientSpec extends ObjectBehavior
 
     function it_search_for_packages(HttpClient $client, Factory $factory, Request $request, Response $response)
     {
-        $client->get('https://packagist.org/search.json?q=sylius')->shouldBeCalled()->willReturn($request);
+        $client->get('https://packagist.org/search.json?q=sylius')->shouldBeCalled()->willReturn($response);
         $data = file_get_contents('spec/Packagist/Api/Fixture/search.json');
         $response->getBody(true)->shouldBeCalled()->willReturn($data);
         $factory->create(json_decode($data, true))->shouldBeCalled()->willReturn(array());
@@ -37,7 +37,7 @@ class ClientSpec extends ObjectBehavior
 
     function it_searches_for_packages_with_filters(HttpClient $client, Factory $factory, Request $request, Response $response)
     {
-        $client->get('https://packagist.org/search.json?tag=storage&q=sylius')->shouldBeCalled()->willReturn($request);
+        $client->get('https://packagist.org/search.json?tag=storage&q=sylius')->shouldBeCalled()->willReturn($response);
         $data = file_get_contents('spec/Packagist/Api/Fixture/search.json');
         $response->getBody(true)->shouldBeCalled()->willReturn($data);
         $factory->create(json_decode($data, true))->shouldBeCalled()->willReturn(array());
@@ -57,7 +57,7 @@ class ClientSpec extends ObjectBehavior
 
     function it_gets_package_details(HttpClient $client, Factory $factory, Request $request, Response $response)
     {
-        $client->get('https://packagist.org/packages/sylius/sylius.json')->shouldBeCalled()->willReturn($request);
+        $client->get('https://packagist.org/packages/sylius/sylius.json')->shouldBeCalled()->willReturn($response);
         $data = file_get_contents('spec/Packagist/Api/Fixture/get.json');
         $response->getBody(true)->shouldBeCalled()->willReturn($data);
         $factory->create(json_decode($data, true))->shouldBeCalled();
@@ -67,7 +67,7 @@ class ClientSpec extends ObjectBehavior
 
     function it_lists_all_package_names(HttpClient $client, Factory $factory, Request $request, Response $response)
     {
-        $client->get('https://packagist.org/packages/list.json')->shouldBeCalled()->willReturn($request);
+        $client->get('https://packagist.org/packages/list.json')->shouldBeCalled()->willReturn($response);
         $data = file_get_contents('spec/Packagist/Api/Fixture/all.json');
         $response->getBody(true)->shouldBeCalled()->willReturn($data);
         $factory->create(json_decode($data, true))->shouldBeCalled();
@@ -77,7 +77,7 @@ class ClientSpec extends ObjectBehavior
 
     function it_filters_package_names_by_type(HttpClient $client, Factory $factory, Request $request, Response $response)
     {
-        $client->get('https://packagist.org/packages/list.json?type=library')->shouldBeCalled()->willReturn($request);
+        $client->get('https://packagist.org/packages/list.json?type=library')->shouldBeCalled()->willReturn($response);
         $data = file_get_contents('spec/Packagist/Api/Fixture/all.json');
         $response->getBody(true)->shouldBeCalled()->willReturn($data);
         $factory->create(json_decode($data, true))->shouldBeCalled();
@@ -87,7 +87,7 @@ class ClientSpec extends ObjectBehavior
 
     function it_filters_package_names_by_vendor(HttpClient $client, Factory $factory, Request $request, Response $response)
     {
-        $client->get('https://packagist.org/packages/list.json?vendor=sylius')->shouldBeCalled()->willReturn($request);
+        $client->get('https://packagist.org/packages/list.json?vendor=sylius')->shouldBeCalled()->willReturn($response);
         $data = file_get_contents('spec/Packagist/Api/Fixture/all.json');
         $response->getBody(true)->shouldBeCalled()->willReturn($data);
         $factory->create(json_decode($data, true))->shouldBeCalled();

--- a/src/Packagist/Api/Client.php
+++ b/src/Packagist/Api/Client.php
@@ -2,8 +2,8 @@
 
 namespace Packagist\Api;
 
-use Guzzle\Http\Client as HttpClient;
-use Guzzle\Http\ClientInterface;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\ClientInterface;
 use Packagist\Api\Result\Factory;
 
 /**
@@ -178,7 +178,7 @@ class Client
      *
      * @param string $url
      *
-     * @return \Guzzle\Http\EntityBodyInterface|string
+     * @return \GuzzleHttp\Stream\StreamInterface|string
      */
     protected function request($url)
     {
@@ -188,7 +188,6 @@ class Client
 
         return $this->httpClient
             ->get($url)
-            ->send()
             ->getBody(true)
         ;
     }


### PR DESCRIPTION
This is simply a rebased copy of #25  It appeared that @pocallaghan just needed to resolve conflicts in order to get this merged.

The guzzle 3 project is deprecated, upgraded to depend on guzzle 5
instead.