### PR TITLE
Add GitHub forks and GitHub stars

### DIFF
--- a/spec/Packagist/Api/Result/PackageSpec.php
+++ b/spec/Packagist/Api/Result/PackageSpec.php
@@ -28,6 +28,8 @@ class PackageSpec extends ObjectBehavior
             'favers'      => 9999999999,
             'suggesters'  => 21,
             'dependents'  => 42,
+            'github_stars' => 3086,
+            'github_forks' => 1124
         ));
     }
 
@@ -99,5 +101,15 @@ class PackageSpec extends ObjectBehavior
     function it_gets_dependents()
     {
         $this->getDependents()->shouldReturn(42);
+    }
+
+    function it_gets_github_stars()
+    {
+        $this->getGithubStars()->shouldReturn(3086);
+    }
+
+    function it_gets_github_forks()
+    {
+        $this->getGithubForks()->shouldReturn(1124);
     }
 }

--- a/src/Packagist/Api/Result/Package.php
+++ b/src/Packagist/Api/Result/Package.php
@@ -65,6 +65,16 @@ class Package extends AbstractResult
     protected $dependents = 0;
 
     /**
+     * @var integer
+     */
+    protected $githubStars = 0;
+
+    /**
+     * @var integer
+     */
+    protected $githubForks = 0;
+
+    /**
      * @return string
      */
     public function getName()
@@ -158,5 +168,21 @@ class Package extends AbstractResult
     public function getDependents()
     {
         return $this->dependents;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getGithubStars()
+    {
+        return $this->githubStars;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getGithubForks()
+    {
+        return $this->githubForks;
     }
 }


### PR DESCRIPTION
This PR adds the githubForks and githubStars property to the package. 

Packagist provides the number of GitHub forks and GitHub stars.
For instance, you can find this information here:
https://packagist.org/packages/sylius/sylius.json 