### PR TITLE
Add getAbandoned() to return bool or string, deprecate isAbandoned()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,8 @@
+# Upgrade notes
+
+## 1.6.0 (unreleased)
+
+* `Packagist\Api\Result\Package::isAbandoned()` is now deprecated. Use `Packagist\Api\Result\Package::isAbandoned()`
+  instead, which returns a boolean or a string (package name to use as a replacement).
+* `Packagist\Api\Result\Package\Version::isAbandoned()` is now deprecated. See above.
+* Dropped support for PHP lower than 7.1.0.

--- a/spec/Packagist/Api/Result/Package/VersionSpec.php
+++ b/spec/Packagist/Api/Result/Package/VersionSpec.php
@@ -7,10 +7,10 @@ use PhpSpec\ObjectBehavior;
 class VersionSpec extends ObjectBehavior
 {
     /**
-     * @param Packagist\Api\Result\Package\Author $author
-     * @param Packagist\Api\Result\Package\Source $source
-     * @param Packagist\Api\Result\Package\Dist   $dist
-     * @param DateTime                            $time
+     * @param \Packagist\Api\Result\Package\Author $author
+     * @param \Packagist\Api\Result\Package\Source $source
+     * @param \Packagist\Api\Result\Package\Dist   $dist
+     * @param \DateTime                            $time
      */
     function let($author, $source, $dist, $time)
     {
@@ -136,8 +136,24 @@ class VersionSpec extends ObjectBehavior
         $this->getSuggest()->shouldReturn(array('illuminate/events' => 'Required to use the observers with Eloquent (5.1.*).'));
     }
 
-    function it_gets_abandoned()
+    function it_gets_abandoned_bool()
     {
         $this->isAbandoned()->shouldReturn(false);
+    }
+
+    function it_gets_abandoned_package_replacement()
+    {
+        $this->fromArray(array(
+            'name'               => 'typo3/ldap',
+            'description'        => 'Ldap Authentication for Flow',
+            'version'            => 'dev-checkout',
+            'version_normalized' => 'dev-checkout',
+            'type'               => 'library',
+            'abandoned'          => 'neos/ldap',
+        ));
+
+        $this->getAbandoned()->shouldReturn('neos/ldap');
+        // Deprecated/legacy flag
+        $this->isAbandoned()->shouldReturn(true);
     }
 }

--- a/spec/Packagist/Api/Result/PackageSpec.php
+++ b/spec/Packagist/Api/Result/PackageSpec.php
@@ -7,12 +7,12 @@ use PhpSpec\ObjectBehavior;
 class PackageSpec extends ObjectBehavior
 {
     /**
-     * @param Packagist\Api\Result\Package\Maintainer $maintainer
-     * @param Packagist\Api\Result\Package\Version    $version
-     * @param Packagist\Api\Result\Package\Source     $source
-     * @param Packagist\Api\Result\Package\Dist       $dist
-     * @param Packagist\Api\Result\Package\Downloads  $downloads
-     * @param DateTime                                $time
+     * @param \Packagist\Api\Result\Package\Maintainer $maintainer
+     * @param \Packagist\Api\Result\Package\Version    $version
+     * @param \Packagist\Api\Result\Package\Source     $source
+     * @param \Packagist\Api\Result\Package\Dist       $dist
+     * @param \Packagist\Api\Result\Package\Downloads  $downloads
+     * @param \DateTime                                $time
      */
     function let($maintainer, $version, $source, $dist, $downloads, $time)
     {
@@ -88,9 +88,23 @@ class PackageSpec extends ObjectBehavior
         $this->getFavers()->shouldReturn(9999999999);
     }
 
-    function it_gets_abandoned()
+    function it_gets_abandoned_bool()
     {
         $this->isAbandoned()->shouldReturn(false);
+    }
+
+    function it_gets_abandoned_package_replacement()
+    {
+        $this->fromArray(array(
+            'name'        => 'typo3/ldap',
+            'description' => 'Ldap Authentication for Flow',
+            'type'        => 'library',
+            'abandoned'   => 'neos/ldap',
+        ));
+
+        $this->getAbandoned()->shouldReturn('neos/ldap');
+        // Deprecated/legacy flag
+        $this->isAbandoned()->shouldReturn(true);
     }
 
     function it_gets_suggesters()

--- a/src/Packagist/Api/Result/Package.php
+++ b/src/Packagist/Api/Result/Package.php
@@ -156,6 +156,12 @@ class Package extends AbstractResult
     }
 
     /**
+     * The Packagist API will either return a boolean, or a string value for `abandoned`. It will be a boolean
+     * if no replacement package was provided when the package was marked as abandoned in Packagist, or it will be
+     * a string containing the replacement package name to use if one was provided.
+     *
+     * @see https://github.com/KnpLabs/packagist-api/pull/56#discussion_r306426997
+     *
      * @return bool|string
      */
     public function getAbandoned()

--- a/src/Packagist/Api/Result/Package.php
+++ b/src/Packagist/Api/Result/Package.php
@@ -50,7 +50,7 @@ class Package extends AbstractResult
     protected $favers;
 
     /**
-     * @var bool
+     * @var bool|string
      */
     protected $abandoned = false;
 
@@ -147,9 +147,18 @@ class Package extends AbstractResult
     }
 
     /**
+     * @deprecated 1.6.0 Use getAbandoned() instead
      * @return bool
      */
     public function isAbandoned()
+    {
+        return (bool) $this->abandoned;
+    }
+
+    /**
+     * @return bool|string
+     */
+    public function getAbandoned()
     {
         return $this->abandoned;
     }

--- a/src/Packagist/Api/Result/Package/Version.php
+++ b/src/Packagist/Api/Result/Package/Version.php
@@ -112,7 +112,7 @@ class Version extends AbstractResult
     protected $suggest;
 
     /**
-     * @var bool
+     * @var bool|string
      */
     protected $abandoned = false;
 
@@ -285,9 +285,18 @@ class Version extends AbstractResult
     }
 
     /**
+     * @deprecated 1.6.0 Use getAbandoned() instead
      * @return bool
      */
     public function isAbandoned()
+    {
+        return (bool) $this->abandoned;
+    }
+
+    /**
+     * @return bool|string
+     */
+    public function getAbandoned()
     {
         return $this->abandoned;
     }

--- a/src/Packagist/Api/Result/Package/Version.php
+++ b/src/Packagist/Api/Result/Package/Version.php
@@ -294,6 +294,12 @@ class Version extends AbstractResult
     }
 
     /**
+     * The Packagist API will either return a boolean, or a string value for `abandoned`. It will be a boolean
+     * if no replacement package was provided when the package was marked as abandoned in Packagist, or it will be
+     * a string containing the replacement package name to use if one was provided.
+     *
+     * @see https://github.com/KnpLabs/packagist-api/pull/56#discussion_r306426997
+     *
      * @return bool|string
      */
     public function getAbandoned()


### PR DESCRIPTION
This should be safe as a minor semver change (targetting a 1.6.0) release.

The `abandoned` prop from the Packagist API can either be a boolean OR a string indicating a replacement package name. This PR deprecates isAbandoned() (which indicates boolean value) while casting the prop as a boolean for backwards compatibility, and adds getAbandoned() which can return a bool or string.

Resolves #55