### PR TITLE
Add getReplacementPackage() for abandoned packages and package versions

### DIFF
--- a/spec/Packagist/Api/Result/Package/VersionSpec.php
+++ b/spec/Packagist/Api/Result/Package/VersionSpec.php
@@ -7,10 +7,10 @@ use PhpSpec\ObjectBehavior;
 class VersionSpec extends ObjectBehavior
 {
     /**
-     * @param Packagist\Api\Result\Package\Author $author
-     * @param Packagist\Api\Result\Package\Source $source
-     * @param Packagist\Api\Result\Package\Dist   $dist
-     * @param DateTime                            $time
+     * @param \Packagist\Api\Result\Package\Author $author
+     * @param \Packagist\Api\Result\Package\Source $source
+     * @param \Packagist\Api\Result\Package\Dist   $dist
+     * @param \DateTime                            $time
      */
     function let($author, $source, $dist, $time)
     {
@@ -139,5 +139,35 @@ class VersionSpec extends ObjectBehavior
     function it_gets_abandoned()
     {
         $this->isAbandoned()->shouldReturn(false);
+    }
+
+    function it_gets_abandoned_returning_true()
+    {
+        $this->fromArray([
+            'name'        => 'typo3/ldap',
+            'abandoned'   => true,
+        ]);
+
+        $this->isAbandoned()->shouldReturn(true);
+    }
+
+    function it_gets_replacement_package()
+    {
+        $this->fromArray([
+            'name'        => 'typo3/ldap',
+            'abandoned'   => 'neos/ldap',
+        ]);
+
+        $this->getReplacementPackage()->shouldReturn('neos/ldap');
+    }
+
+    function it_gets_replacement_package_returning_null()
+    {
+        $this->fromArray([
+            'name'        => 'typo3/ldap',
+            'abandoned'   => false,
+        ]);
+
+        $this->getReplacementPackage()->shouldReturn(null);
     }
 }

--- a/spec/Packagist/Api/Result/PackageSpec.php
+++ b/spec/Packagist/Api/Result/PackageSpec.php
@@ -7,12 +7,12 @@ use PhpSpec\ObjectBehavior;
 class PackageSpec extends ObjectBehavior
 {
     /**
-     * @param Packagist\Api\Result\Package\Maintainer $maintainer
-     * @param Packagist\Api\Result\Package\Version    $version
-     * @param Packagist\Api\Result\Package\Source     $source
-     * @param Packagist\Api\Result\Package\Dist       $dist
-     * @param Packagist\Api\Result\Package\Downloads  $downloads
-     * @param DateTime                                $time
+     * @param \Packagist\Api\Result\Package\Maintainer $maintainer
+     * @param \Packagist\Api\Result\Package\Version    $version
+     * @param \Packagist\Api\Result\Package\Source     $source
+     * @param \Packagist\Api\Result\Package\Dist       $dist
+     * @param \Packagist\Api\Result\Package\Downloads  $downloads
+     * @param \DateTime                                $time
      */
     function let($maintainer, $version, $source, $dist, $downloads, $time)
     {
@@ -91,6 +91,36 @@ class PackageSpec extends ObjectBehavior
     function it_gets_abandoned()
     {
         $this->isAbandoned()->shouldReturn(false);
+    }
+
+    function it_gets_abandoned_returning_true()
+    {
+        $this->fromArray([
+            'name'        => 'typo3/ldap',
+            'abandoned'   => true,
+        ]);
+
+        $this->isAbandoned()->shouldReturn(true);
+    }
+
+    function it_gets_replacement_package()
+    {
+        $this->fromArray([
+            'name'        => 'typo3/ldap',
+            'abandoned'   => 'neos/ldap',
+        ]);
+
+        $this->getReplacementPackage()->shouldReturn('neos/ldap');
+    }
+
+    function it_gets_replacement_package_returning_null()
+    {
+        $this->fromArray([
+            'name'        => 'typo3/ldap',
+            'abandoned'   => false,
+        ]);
+
+        $this->getReplacementPackage()->shouldReturn(null);
     }
 
     function it_gets_suggesters()

--- a/src/Packagist/Api/Result/Package.php
+++ b/src/Packagist/Api/Result/Package.php
@@ -50,7 +50,7 @@ class Package extends AbstractResult
     protected $favers;
 
     /**
-     * @var bool
+     * @var bool|string
      */
     protected $abandoned = false;
 
@@ -151,7 +151,25 @@ class Package extends AbstractResult
      */
     public function isAbandoned()
     {
-        return $this->abandoned;
+        return (bool) $this->abandoned;
+    }
+
+    /**
+     * Gets the package name to use as a replacement if this package is abandoned
+     *
+     * @return string|null
+     */
+    public function getReplacementPackage(): ?string
+    {
+        // The Packagist API will either return a boolean, or a string value for `abandoned`. It will be a boolean
+        // if no replacement package was provided when the package was marked as abandoned in Packagist, or it will be
+        // a string containing the replacement package name to use if one was provided.
+        // @see https://github.com/KnpLabs/packagist-api/pull/56#discussion_r306426997
+        if (is_string($this->abandoned)) {
+            return $this->abandoned;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Packagist/Api/Result/Package/Version.php
+++ b/src/Packagist/Api/Result/Package/Version.php
@@ -112,7 +112,7 @@ class Version extends AbstractResult
     protected $suggest;
 
     /**
-     * @var bool
+     * @var bool|string
      */
     protected $abandoned = false;
 
@@ -289,6 +289,24 @@ class Version extends AbstractResult
      */
     public function isAbandoned()
     {
-        return $this->abandoned;
+        return (bool) $this->abandoned;
+    }
+
+    /**
+     * Gets the package name to use as a replacement if this package is abandoned
+     *
+     * @return string|null
+     */
+    public function getReplacementPackage(): ?string
+    {
+        // The Packagist API will either return a boolean, or a string value for `abandoned`. It will be a boolean
+        // if no replacement package was provided when the package was marked as abandoned in Packagist, or it will be
+        // a string containing the replacement package name to use if one was provided.
+        // @see https://github.com/KnpLabs/packagist-api/pull/56#discussion_r306426997
+        if (is_string($this->abandoned)) {
+            return $this->abandoned;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Replaces https://github.com/KnpLabs/packagist-api/pull/56 and resolves #55

`abandoned` can return a boolean or a string from the Packagist API. This adds new getters for "replacement package" (name) to Package and Package\Version, future proofing in case Packagist changes the API to add a `replacementPackage` property to it (as their website uses already - see https://github.com/composer/packagist/blob/06502cc/src/Packagist/WebBundle/Resources/views/package/view_package.html.twig#L66-L78)