### PR TITLE
Upgrade phpspec to 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/inflector": "~1.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "~2.0",
+        "phpspec/phpspec": "~5.1",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "config": {

--- a/spec/Packagist/Api/Result/FactorySpec.php
+++ b/spec/Packagist/Api/Result/FactorySpec.php
@@ -86,7 +86,7 @@ class FactorySpec extends ObjectBehavior
         $this->create($data)->shouldHaveType('Packagist\Api\Result\Package');
     }
 
-    public function getMatchers()
+    public function getMatchers(): array
     {
         return array(
             'haveBranch'  => function($subject, $key) {


### PR DESCRIPTION
Now that the master branch requires PHP 7.1, we can use PHPSpec 5.1 which also supports PHP 7.3.

Resolves https://github.com/KnpLabs/packagist-api/issues/52