### PR TITLE
Update to require PHP 7.4 as the minimum version, add strict typing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,json}]
+indent_size = 2
+
+[composer.json]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /spec export-ignore
 /examples export-ignore
+/.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-bin/*
 composer.lock
 vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,11 @@ sudo: false
 language: php
 
 php:
-  - '7.1'
-  - '7.2'
-  - '7.3'
   - '7.4'
 
 before_script:
   - composer install --dev
 
 script:
-  - php bin/phpspec run -f pretty
-  - php bin/phpcs --standard=PSR2 src/
+  - php vendor/bin/phpspec run -f pretty
+  - php vendor/bin/phpcs --standard=PSR12 src/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple object oriented wrapper for Packagist API.
 
 ## Requirements
 
-* PHP ^7.1
+* PHP ^7.4 (for PHP 7.1-7.3 please use the 1.6.x release line)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.4",
         "guzzlehttp/guzzle": "~6.0",
         "doctrine/inflector": "~1.0 || ~2.0"
     },
@@ -24,13 +24,13 @@
         "bin-dir": "bin"
     },
     "autoload": {
-        "psr-0": {
-            "Packagist\\Api\\": "src/"
+        "psr-4": {
+            "Packagist\\Api\\": "src/Packagist/Api/"
         }
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,21 @@
     "require": {
         "php": ">=7.4",
         "guzzlehttp/guzzle": "~6.0",
-        "doctrine/inflector": "~1.0 || ~2.0"
-    },
+        "doctrine/inflector": "~2.0",
+        "ext-json": "*"
+	},
     "require-dev": {
-        "phpspec/phpspec": "~5.1 || ~6.0",
+        "phpspec/phpspec": "~6.0",
         "squizlabs/php_codesniffer": "^3.0"
-    },
-    "config": {
-        "bin-dir": "bin"
     },
     "autoload": {
         "psr-4": {
             "Packagist\\Api\\": "src/Packagist/Api/"
+        }
+    },
+	"autoload-dev": {
+        "psr-4": {
+            "spec\\Packagist\\Api\\": "spec/Packagist/Api/"
         }
     },
     "extra": {

--- a/spec/Packagist/Api/ClientSpec.php
+++ b/spec/Packagist/Api/ClientSpec.php
@@ -1,108 +1,123 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api;
-
-use PhpSpec\ObjectBehavior;
-use PhpSpec\Exception\Example\MatcherException;
-
-use Packagist\Api\Client;
-use Packagist\Api\Result\Factory;
 
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Psr7\Response;
+use Packagist\Api\Client;
+use Packagist\Api\Result\Factory;
+use PhpSpec\ObjectBehavior;
 
 class ClientSpec extends ObjectBehavior
 {
-    function let(HttpClient $client, Factory $factory)
+    public function let(HttpClient $client, Factory $factory)
     {
         $this->beConstructedWith($client, $factory);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Client');
+        $this->shouldHaveType(Client::class);
     }
 
-    function it_search_for_packages(HttpClient $client, Factory $factory, Response $response)
+    public function it_search_for_packages(HttpClient $client, Factory $factory, Response $response)
     {
         $data = file_get_contents('spec/Packagist/Api/Fixture/search.json');
         $response->getBody()->shouldBeCalled()->willReturn($data);
 
-        $client->request('get', 'https://packagist.org/search.json?q=sylius')->shouldBeCalled()->willReturn($response);
-        $factory->create(json_decode($data, true))->shouldBeCalled()->willReturn(array());
+        $client->request('get', 'https://packagist.org/search.json?q=sylius')
+			->shouldBeCalled()
+			->willReturn($response);
+        $factory->create(json_decode($data, true))->shouldBeCalled()->willReturn([]);
 
         $this->search('sylius');
     }
 
-    function it_searches_for_packages_with_filters(HttpClient $client, Factory $factory, Response $response)
+    public function it_searches_for_packages_with_filters(HttpClient $client, Factory $factory, Response $response)
     {
         $data = file_get_contents('spec/Packagist/Api/Fixture/search.json');
         $response->getBody()->shouldBeCalled()->willReturn($data);
 
-        $client->request('get', 'https://packagist.org/search.json?tag=storage&q=sylius')->shouldBeCalled()->willReturn($response);
+        $client->request('get', 'https://packagist.org/search.json?tag=storage&q=sylius')
+			->shouldBeCalled()
+			->willReturn($response);
 
-        $factory->create(json_decode($data, true))->shouldBeCalled()->willReturn(array());
+        $factory->create(json_decode($data, true))->shouldBeCalled()->willReturn([]);
 
-        $this->search('sylius', array('tag' => 'storage'));
+        $this->search('sylius', ['tag' => 'storage']);
     }
 
-    function it_gets_popular_packages(HttpClient $client, Factory $factory, Response $response)
+    public function it_gets_popular_packages(HttpClient $client, Factory $factory, Response $response)
     {
         $data = file_get_contents('spec/Packagist/Api/Fixture/popular.json');
         $response->getBody()->shouldBeCalled()->willReturn($data);
 
-        $client->request('get', 'https://packagist.org/explore/popular.json?page=1')->shouldBeCalled()->willReturn($response);
+        $client->request('get', 'https://packagist.org/explore/popular.json?page=1')
+			->shouldBeCalled()
+			->willReturn($response);
 
-        $factory->create(json_decode($data, true))->shouldBeCalled()->willReturn(array_pad(array(), 5, null));
+        $factory->create(json_decode($data, true))
+			->shouldBeCalled()
+			->willReturn(array_pad([], 5, null));
 
         $this->popular(2)->shouldHaveCount(2);
     }
 
-    function it_gets_package_details(HttpClient $client, Factory $factory, Response $response)
+    public function it_gets_package_details(HttpClient $client, Factory $factory, Response $response)
     {
         $data = file_get_contents('spec/Packagist/Api/Fixture/get.json');
         $response->getBody()->shouldBeCalled()->willReturn($data);
 
-        $client->request('get', 'https://packagist.org/packages/sylius/sylius.json')->shouldBeCalled()->willReturn($response);
+        $client->request('get', 'https://packagist.org/packages/sylius/sylius.json')
+			->shouldBeCalled()
+			->willReturn($response);
 
         $factory->create(json_decode($data, true))->shouldBeCalled();
 
         $this->get('sylius/sylius');
     }
 
-    function it_lists_all_package_names(HttpClient $client, Factory $factory, Response $response)
+    public function it_lists_all_package_names(HttpClient $client, Factory $factory, Response $response)
     {
         $data = file_get_contents('spec/Packagist/Api/Fixture/all.json');
         $response->getBody()->shouldBeCalled()->willReturn($data);
 
-        $client->request('get', 'https://packagist.org/packages/list.json')->shouldBeCalled()->willReturn($response);
+        $client->request('get', 'https://packagist.org/packages/list.json')
+			->shouldBeCalled()
+			->willReturn($response);
 
         $factory->create(json_decode($data, true))->shouldBeCalled();
 
         $this->all();
     }
 
-    function it_filters_package_names_by_type(HttpClient $client, Factory $factory, Response $response)
+    public function it_filters_package_names_by_type(HttpClient $client, Factory $factory, Response $response)
     {
         $data = file_get_contents('spec/Packagist/Api/Fixture/all.json');
         $response->getBody()->shouldBeCalled()->willReturn($data);
 
-        $client->request('get', 'https://packagist.org/packages/list.json?type=library')->shouldBeCalled()->willReturn($response);
+        $client->request('get', 'https://packagist.org/packages/list.json?type=library')
+			->shouldBeCalled()
+			->willReturn($response);
 
         $factory->create(json_decode($data, true))->shouldBeCalled();
 
-        $this->all(array('type' => 'library'));
+        $this->all(['type' => 'library']);
     }
 
-    function it_filters_package_names_by_vendor(HttpClient $client, Factory $factory, Response $response)
+    public function it_filters_package_names_by_vendor(HttpClient $client, Factory $factory, Response $response)
     {
         $data = file_get_contents('spec/Packagist/Api/Fixture/all.json');
         $response->getBody()->shouldBeCalled()->willReturn($data);
 
-        $client->request('get', 'https://packagist.org/packages/list.json?vendor=sylius')->shouldBeCalled()->willReturn($response);
+        $client->request('get', 'https://packagist.org/packages/list.json?vendor=sylius')
+			->shouldBeCalled()
+			->willReturn($response);
 
         $factory->create(json_decode($data, true))->shouldBeCalled();
 
-        $this->all(array('vendor' => 'sylius'));
+        $this->all(['vendor' => 'sylius']);
     }
 }

--- a/spec/Packagist/Api/Result/FactorySpec.php
+++ b/spec/Packagist/Api/Result/FactorySpec.php
@@ -1,17 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api\Result;
 
+use Packagist\Api\Result\Factory;
+use Packagist\Api\Result\Package;
+use Packagist\Api\Result\Result;
 use PhpSpec\ObjectBehavior;
 
 class FactorySpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Result\Factory');
+        $this->shouldHaveType(Factory::class);
     }
 
-    function it_creates_search_results()
+    public function it_creates_search_results()
     {
         $data = json_decode(file_get_contents('spec/Packagist/Api/Fixture/search.json'), true);
 
@@ -19,11 +24,11 @@ class FactorySpec extends ObjectBehavior
         $results->shouldHaveCount(2);
         $results->shouldBeArray();
         foreach ($results as $result) {
-            $result->shouldBeAnInstanceOf('Packagist\Api\Result\Result');
+            $result->shouldBeAnInstanceOf(Result::class);
         }
     }
 
-    function it_creates_popular_results()
+    public function it_creates_popular_results()
     {
         $data = json_decode(file_get_contents('spec/Packagist/Api/Fixture/popular.json'), true);
 
@@ -31,59 +36,59 @@ class FactorySpec extends ObjectBehavior
         $results->shouldHaveCount(2);
         $results->shouldBeArray();
         foreach ($results as $result) {
-            $result->shouldBeAnInstanceOf('Packagist\Api\Result\Result');
+            $result->shouldBeAnInstanceOf(Result::class);
         }
     }
 
-    function it_creates_packages()
+    public function it_creates_packages()
     {
         $data = json_decode(file_get_contents('spec/Packagist/Api/Fixture/get.json'), true);
 
-        $this->create($data)->shouldHaveType('Packagist\Api\Result\Package');
+        $this->create($data)->shouldHaveType(Package::class);
     }
 
-    function it_creates_package_names()
+    public function it_creates_package_names()
     {
         $data = json_decode(file_get_contents('spec/Packagist/Api/Fixture/all.json'), true);
 
-        $this->create($data)->shouldReturn(array(
+        $this->create($data)->shouldReturn([
             'sylius/addressing-bundle',
             'sylius/assortment-bundle',
-            'sylius/blogger-bundle'
-        ));
+            'sylius/blogger-bundle',
+        ]);
     }
 
-    function it_creates_packages_with_missing_optional_data()
+    public function it_creates_packages_with_missing_optional_data()
     {
         $data = json_decode(file_get_contents('spec/Packagist/Api/Fixture/get_nodist.json'), true);
 
-        $this->create($data)->shouldHaveType('Packagist\Api\Result\Package');
+        $this->create($data)->shouldHaveType(Package::class);
     }
 
-    function it_creates_abandoned_packages()
+    public function it_creates_abandoned_packages()
     {
         $data = json_decode(file_get_contents('spec/Packagist/Api/Fixture/get_abandoned.json'), true);
 
-        $this->create($data)->shouldHaveType('Packagist\Api\Result\Package');
+        $this->create($data)->shouldHaveType(Package::class);
     }
 
-    function it_creates_packages_with_suggesters()
+    public function it_creates_packages_with_suggesters()
     {
         $data = json_decode(file_get_contents('spec/Packagist/Api/Fixture/get_suggesters.json'), true);
-        $this->create($data)->shouldHaveType('Packagist\Api\Result\Package');
+        $this->create($data)->shouldHaveType(Package::class);
     }
 
-    function it_creates_packages_with_dependents()
+    public function it_creates_packages_with_dependents()
     {
         $data = json_decode(file_get_contents('spec/Packagist/Api/Fixture/get_dependents.json'), true);
-        $this->create($data)->shouldHaveType('Packagist\Api\Result\Package');
+        $this->create($data)->shouldHaveType(Package::class);
     }
 
-    function it_creates_packages_with_null_source()
+    public function it_creates_packages_with_null_source()
     {
         $data = json_decode(file_get_contents('spec/Packagist/Api/Fixture/get_null_source.json'), true);
 
-        $this->create($data)->shouldHaveType('Packagist\Api\Result\Package');
+        $this->create($data)->shouldHaveType(Package::class);
     }
 
     public function getMatchers(): array

--- a/spec/Packagist/Api/Result/Package/AuthorSpec.php
+++ b/spec/Packagist/Api/Result/Package/AuthorSpec.php
@@ -1,42 +1,45 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api\Result\Package;
 
+use Packagist\Api\Result\Package\Author;
 use PhpSpec\ObjectBehavior;
 
 class AuthorSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
-        $this->fromArray(array(
+        $this->fromArray([
             'name'     => 'Saša Stamenković',
             'email'    => 'umpirsky@gmail.com',
             'homepage' => 'umpirsky.com',
-            'role'     => 'lead'
-        ));
+            'role'     => 'lead',
+        ]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Result\Package\Author');
+        $this->shouldHaveType(Author::class);
     }
 
-    function it_gets_name()
+    public function it_gets_name()
     {
         $this->getName()->shouldReturn('Saša Stamenković');
     }
 
-    function it_gets_email()
+    public function it_gets_email()
     {
         $this->getEmail()->shouldReturn('umpirsky@gmail.com');
     }
 
-    function it_gets_homepage()
+    public function it_gets_homepage()
     {
         $this->getHomepage()->shouldReturn('umpirsky.com');
     }
 
-    function it_gets_role()
+    public function it_gets_role()
     {
         $this->getRole()->shouldReturn('lead');
     }

--- a/spec/Packagist/Api/Result/Package/DistSpec.php
+++ b/spec/Packagist/Api/Result/Package/DistSpec.php
@@ -1,42 +1,45 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api\Result\Package;
 
+use Packagist\Api\Result\Package\Dist;
 use PhpSpec\ObjectBehavior;
 
 class DistSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
-        $this->fromArray(array(
+        $this->fromArray([
             'type'      => 'git',
             'url'       => 'https://github.com/Sylius/Sylius.git',
             'reference' => 'cb0a489db41707d5df078f1f35e028e04ffd9e8e',
             'shasum'    => 'cb0a489db41707d5df078f1f35e028e04ffd9e8e',
-        ));
+        ]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Result\Package\Dist');
+        $this->shouldHaveType(Dist::class);
     }
 
-    function it_gets_type()
+    public function it_gets_type()
     {
         $this->getType()->shouldReturn('git');
     }
 
-    function it_gets_url()
+    public function it_gets_url()
     {
         $this->getUrl()->shouldReturn('https://github.com/Sylius/Sylius.git');
     }
 
-    function it_gets_reference()
+    public function it_gets_reference()
     {
         $this->getReference()->shouldReturn('cb0a489db41707d5df078f1f35e028e04ffd9e8e');
     }
 
-    function it_gets_shasum()
+    public function it_gets_shasum()
     {
         $this->getShasum()->shouldReturn('cb0a489db41707d5df078f1f35e028e04ffd9e8e');
     }

--- a/spec/Packagist/Api/Result/Package/DownloadsSpec.php
+++ b/spec/Packagist/Api/Result/Package/DownloadsSpec.php
@@ -1,53 +1,56 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api\Result\Package;
 
+use Packagist\Api\Result\Package\Downloads;
 use PhpSpec\ObjectBehavior;
 
 class DownloadsSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
-        $this->fromArray(array(
+        $this->fromArray([
             'total'   => 9999999,
             'monthly' => 99999,
             'daily'   => 999,
-        ));
+        ]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Result\Package\Downloads');
+        $this->shouldHaveType(Downloads::class);
     }
 
-    function it_gets_total()
+    public function it_gets_total()
     {
         $this->getTotal()->shouldReturn(9999999);
     }
 
-    function its_total_is_mutable()
+    public function its_total_is_mutable()
     {
         $this->setTotal(111);
         $this->getTotal()->shouldReturn(111);
     }
 
-    function it_gets_monthly()
+    public function it_gets_monthly()
     {
         $this->getMonthly()->shouldReturn(99999);
     }
 
-    function its_monthly_is_mutable()
+    public function its_monthly_is_mutable()
     {
         $this->setMonthly(111);
         $this->getMonthly()->shouldReturn(111);
     }
 
-    function it_gets_daily()
+    public function it_gets_daily()
     {
         $this->getDaily()->shouldReturn(999);
     }
 
-    function its_daily_is_mutable()
+    public function its_daily_is_mutable()
     {
         $this->setDaily(111);
         $this->getDaily()->shouldReturn(111);

--- a/spec/Packagist/Api/Result/Package/MaintainerSpec.php
+++ b/spec/Packagist/Api/Result/Package/MaintainerSpec.php
@@ -1,36 +1,39 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api\Result\Package;
 
+use Packagist\Api\Result\Package\Maintainer;
 use PhpSpec\ObjectBehavior;
 
 class MaintainerSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
-        $this->fromArray(array(
+        $this->fromArray([
             'name'     => 'Saša Stamenković',
             'email'    => 'umpirsky@gmail.com',
-            'homepage' => 'umpirsky.com'
-        ));
+            'homepage' => 'umpirsky.com',
+        ]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Result\Package\Maintainer');
+        $this->shouldHaveType(Maintainer::class);
     }
 
-    function it_gets_name()
+    public function it_gets_name()
     {
         $this->getName()->shouldReturn('Saša Stamenković');
     }
 
-    function it_gets_email()
+    public function it_gets_email()
     {
         $this->getEmail()->shouldReturn('umpirsky@gmail.com');
     }
 
-    function it_gets_homepage()
+    public function it_gets_homepage()
     {
         $this->getHomepage()->shouldReturn('umpirsky.com');
     }

--- a/spec/Packagist/Api/Result/Package/SourceSpec.php
+++ b/spec/Packagist/Api/Result/Package/SourceSpec.php
@@ -1,36 +1,39 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api\Result\Package;
 
+use Packagist\Api\Result\Package\Source;
 use PhpSpec\ObjectBehavior;
 
 class SourceSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
-        $this->fromArray(array(
+        $this->fromArray([
             'type'      => 'zip',
             'url'       => 'https://api.github.com/repos/Sylius/Sylius/zipball/cb0a489db41707d5df078f1f35e028e04ffd9e8e',
             'reference' => 'cb0a489db41707d5df078f1f35e028e04ffd9e8e',
-        ));
+        ]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Result\Package\Source');
+        $this->shouldHaveType(Source::class);
     }
 
-    function it_gets_type()
+    public function it_gets_type()
     {
         $this->getType()->shouldReturn('zip');
     }
 
-    function it_gets_url()
+    public function it_gets_url()
     {
         $this->getUrl()->shouldReturn('https://api.github.com/repos/Sylius/Sylius/zipball/cb0a489db41707d5df078f1f35e028e04ffd9e8e');
     }
 
-    function it_gets_reference()
+    public function it_gets_reference()
     {
         $this->getReference()->shouldReturn('cb0a489db41707d5df078f1f35e028e04ffd9e8e');
     }

--- a/spec/Packagist/Api/Result/Package/VersionSpec.php
+++ b/spec/Packagist/Api/Result/Package/VersionSpec.php
@@ -13,7 +13,7 @@ use PhpSpec\ObjectBehavior;
 
 class VersionSpec extends ObjectBehavior
 {
-    public function let(Author $author, Source $source, Dist $dist, \DateTime $time)
+    public function let(Author $author, Source $source, Dist $dist)
     {
         $this->fromArray([
             'name'               => 'sylius/sylius',
@@ -22,12 +22,12 @@ class VersionSpec extends ObjectBehavior
             'homepage'           => 'http://sylius.com',
             'version'            => 'dev-checkout',
             'version_normalized' => 'dev-checkout',
-            'license'            => 'MIT',
+            'licenses'           => ['MIT'],
             'authors'            => [$author],
             'source'             => $source,
             'dist'               => $dist,
             'type'               => 'library',
-            'time'               => $time,
+            'time'               => '2020-01-25T15:11:19+00:00',
             'autoload'           => ['psr-0' => ['Context' => 'features/']],
             'extra'              => ['symfony-app-dir' => 'sylius'],
             'require'            => ['php' => '>=5.4'],
@@ -77,9 +77,9 @@ class VersionSpec extends ObjectBehavior
         $this->getVersionNormalized()->shouldReturn('dev-checkout');
     }
 
-    public function it_gets_license()
+    public function it_gets_licenses()
     {
-        $this->getLicense()->shouldReturn('MIT');
+        $this->getLicenses()->shouldReturn(['MIT']);
     }
 
     public function it_has_authors($author)
@@ -102,9 +102,9 @@ class VersionSpec extends ObjectBehavior
         $this->getType()->shouldReturn('library');
     }
 
-    public function it_gets_time($time)
+    public function it_gets_time()
     {
-        $this->getTime()->shouldReturn($time);
+        $this->getTime()->shouldReturn('2020-01-25T15:11:19+00:00');
     }
 
     public function it_gets_autoload()

--- a/spec/Packagist/Api/Result/Package/VersionSpec.php
+++ b/spec/Packagist/Api/Result/Package/VersionSpec.php
@@ -1,147 +1,150 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api\Result\Package;
 
+use Packagist\Api\Result\AbstractResult;
+use Packagist\Api\Result\Package\Author;
+use Packagist\Api\Result\Package\Dist;
+use Packagist\Api\Result\Package\Source;
+use Packagist\Api\Result\Package\Version;
 use PhpSpec\ObjectBehavior;
 
 class VersionSpec extends ObjectBehavior
 {
-    /**
-     * @param \Packagist\Api\Result\Package\Author $author
-     * @param \Packagist\Api\Result\Package\Source $source
-     * @param \Packagist\Api\Result\Package\Dist   $dist
-     * @param \DateTime                            $time
-     */
-    function let($author, $source, $dist, $time)
+    public function let(Author $author, Source $source, Dist $dist, \DateTime $time)
     {
-        $this->fromArray(array(
+        $this->fromArray([
             'name'               => 'sylius/sylius',
             'description'        => 'Modern ecommerce for Symfony2',
-            'keywords'           => array('sylius'),
+            'keywords'           => ['sylius'],
             'homepage'           => 'http://sylius.com',
             'version'            => 'dev-checkout',
             'version_normalized' => 'dev-checkout',
             'license'            => 'MIT',
-            'authors'            => array($author),
+            'authors'            => [$author],
             'source'             => $source,
             'dist'               => $dist,
             'type'               => 'library',
             'time'               => $time,
-            'autoload'           => array('psr-0' => array('Context' => 'features/')),
-            'extra'              => array('symfony-app-dir' => 'sylius'),
-            'require'            => array('php' => '>=5.4'),
-            'require-dev'        => array('phpspec/phpspec2' => 'dev-develop'),
-            'suggest'            => array('illuminate/events' => 'Required to use the observers with Eloquent (5.1.*).'),
-            'bin'                => array('bin/sylius'),
-        ));
+            'autoload'           => ['psr-0' => ['Context' => 'features/']],
+            'extra'              => ['symfony-app-dir' => 'sylius'],
+            'require'            => ['php' => '>=5.4'],
+            'require-dev'        => ['phpspec/phpspec2' => 'dev-develop'],
+            'suggest'            => ['illuminate/events' => 'Required to use the observers with Eloquent (5.1.*).'],
+            'bin'                => ['bin/sylius'],
+        ]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Result\Package\Version');
+        $this->shouldHaveType(Version::class);
     }
 
-    function it_is_a_packagist_result()
+    public function it_is_a_packagist_result()
     {
-        $this->shouldHaveType('Packagist\Api\Result\AbstractResult');
+        $this->shouldHaveType(AbstractResult::class);
     }
 
-    function it_gets_name()
+    public function it_gets_name()
     {
         $this->getName()->shouldReturn('sylius/sylius');
     }
 
-    function it_gets_description()
+    public function it_gets_description()
     {
         $this->getDescription()->shouldReturn('Modern ecommerce for Symfony2');
     }
 
-    function it_gets_keywords()
+    public function it_gets_keywords()
     {
-        $this->getKeywords()->shouldReturn(array('sylius'));
+        $this->getKeywords()->shouldReturn(['sylius']);
     }
 
-    function it_gets_homepage()
+    public function it_gets_homepage()
     {
         $this->getHomepage()->shouldReturn('http://sylius.com');
     }
 
-    function it_gets_version()
+    public function it_gets_version()
     {
         $this->getVersion()->shouldReturn('dev-checkout');
     }
 
-    function it_gets_normalized_version()
+    public function it_gets_normalized_version()
     {
         $this->getVersionNormalized()->shouldReturn('dev-checkout');
     }
 
-    function it_gets_license()
+    public function it_gets_license()
     {
         $this->getLicense()->shouldReturn('MIT');
     }
 
-    function it_has_authors($author)
+    public function it_has_authors($author)
     {
-        $this->getAuthors()->shouldReturn(array($author));
+        $this->getAuthors()->shouldReturn([$author]);
     }
 
-    function it_gets_source($source)
+    public function it_gets_source($source)
     {
         $this->getSource()->shouldReturn($source);
     }
 
-    function it_gets_dist($dist)
+    public function it_gets_dist($dist)
     {
         $this->getDist()->shouldReturn($dist);
     }
 
-    function it_gets_type()
+    public function it_gets_type()
     {
         $this->getType()->shouldReturn('library');
     }
 
-    function it_gets_time($time)
+    public function it_gets_time($time)
     {
         $this->getTime()->shouldReturn($time);
     }
 
-    function it_gets_autoload()
+    public function it_gets_autoload()
     {
-        $this->getAutoload()->shouldReturn(array('psr-0' => array('Context' => 'features/')));
+        $this->getAutoload()->shouldReturn(['psr-0' => ['Context' => 'features/']]);
     }
 
-    function it_gets_extra()
+    public function it_gets_extra()
     {
-        $this->getExtra()->shouldReturn(array('symfony-app-dir' => 'sylius'));
+        $this->getExtra()->shouldReturn(['symfony-app-dir' => 'sylius']);
     }
 
-    function it_gets_require()
+    public function it_gets_require()
     {
-        $this->getRequire()->shouldReturn(array('php' => '>=5.4'));
+        $this->getRequire()->shouldReturn(['php' => '>=5.4']);
     }
 
-    function it_gets_require_dev()
+    public function it_gets_require_dev()
     {
-        $this->getRequireDev()->shouldReturn(array('phpspec/phpspec2' => 'dev-develop'));
+        $this->getRequireDev()->shouldReturn(['phpspec/phpspec2' => 'dev-develop']);
     }
 
-    function it_gets_bin()
+    public function it_gets_bin()
     {
-        $this->getBin()->shouldReturn(array('bin/sylius'));
+        $this->getBin()->shouldReturn(['bin/sylius']);
     }
 
-    function it_gets_suggest()
+    public function it_gets_suggest()
     {
-        $this->getSuggest()->shouldReturn(array('illuminate/events' => 'Required to use the observers with Eloquent (5.1.*).'));
+        $this->getSuggest()->shouldReturn([
+        	'illuminate/events' => 'Required to use the observers with Eloquent (5.1.*).',
+		]);
     }
 
-    function it_gets_abandoned()
+    public function it_gets_abandoned()
     {
         $this->isAbandoned()->shouldReturn(false);
     }
 
-    function it_gets_abandoned_returning_true()
+    public function it_gets_abandoned_returning_true()
     {
         $this->fromArray([
             'name'        => 'typo3/ldap',
@@ -151,7 +154,7 @@ class VersionSpec extends ObjectBehavior
         $this->isAbandoned()->shouldReturn(true);
     }
 
-    function it_gets_replacement_package()
+    public function it_gets_replacement_package()
     {
         $this->fromArray([
             'name'        => 'typo3/ldap',
@@ -161,7 +164,7 @@ class VersionSpec extends ObjectBehavior
         $this->getReplacementPackage()->shouldReturn('neos/ldap');
     }
 
-    function it_gets_replacement_package_returning_null()
+    public function it_gets_replacement_package_returning_null()
     {
         $this->fromArray([
             'name'        => 'typo3/ldap',

--- a/spec/Packagist/Api/Result/PackageSpec.php
+++ b/spec/Packagist/Api/Result/PackageSpec.php
@@ -6,21 +6,19 @@ namespace spec\Packagist\Api\Result;
 
 use Packagist\Api\Result\AbstractResult;
 use Packagist\Api\Result\Package;
-use Packagist\Api\Result\Package\Dist;
 use Packagist\Api\Result\Package\Downloads;
 use Packagist\Api\Result\Package\Maintainer;
-use Packagist\Api\Result\Package\Source;
 use Packagist\Api\Result\Package\Version;
 use PhpSpec\ObjectBehavior;
 
 class PackageSpec extends ObjectBehavior
 {
-    public function let(Maintainer $maintainer, Version $version, Source $source, Dist $dist, Downloads $downloads, \DateTime $time)
+    public function let(Maintainer $maintainer, Version $version, Downloads $downloads)
     {
         $this->fromArray([
             'name'        => 'sylius/sylius',
             'description' => 'Modern ecommerce for Symfony2',
-            'time'        => $time,
+            'time'        => '2020-01-25T15:11:19+00:00',
             'maintainers' => [$maintainer],
             'versions'    => [$version],
             'type'        => 'library',
@@ -54,9 +52,9 @@ class PackageSpec extends ObjectBehavior
         $this->getDescription()->shouldReturn('Modern ecommerce for Symfony2');
     }
 
-    public function it_gets_time($time)
+    public function it_gets_time()
     {
-        $this->getTime()->shouldReturn($time);
+        $this->getTime()->shouldReturn('2020-01-25T15:11:19+00:00');
     }
 
     public function it_gets_maintainers($maintainer)

--- a/spec/Packagist/Api/Result/PackageSpec.php
+++ b/spec/Packagist/Api/Result/PackageSpec.php
@@ -1,27 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api\Result;
 
+use Packagist\Api\Result\AbstractResult;
+use Packagist\Api\Result\Package;
+use Packagist\Api\Result\Package\Dist;
+use Packagist\Api\Result\Package\Downloads;
+use Packagist\Api\Result\Package\Maintainer;
+use Packagist\Api\Result\Package\Source;
+use Packagist\Api\Result\Package\Version;
 use PhpSpec\ObjectBehavior;
 
 class PackageSpec extends ObjectBehavior
 {
-    /**
-     * @param \Packagist\Api\Result\Package\Maintainer $maintainer
-     * @param \Packagist\Api\Result\Package\Version    $version
-     * @param \Packagist\Api\Result\Package\Source     $source
-     * @param \Packagist\Api\Result\Package\Dist       $dist
-     * @param \Packagist\Api\Result\Package\Downloads  $downloads
-     * @param \DateTime                                $time
-     */
-    function let($maintainer, $version, $source, $dist, $downloads, $time)
+    public function let(Maintainer $maintainer, Version $version, Source $source, Dist $dist, Downloads $downloads, \DateTime $time)
     {
-        $this->fromArray(array(
+        $this->fromArray([
             'name'        => 'sylius/sylius',
             'description' => 'Modern ecommerce for Symfony2',
             'time'        => $time,
-            'maintainers' => array($maintainer),
-            'versions'    => array($version),
+            'maintainers' => [$maintainer],
+            'versions'    => [$version],
             'type'        => 'library',
             'repository'  => 'https://github.com/Sylius/Sylius.git',
             'downloads'   => $downloads,
@@ -29,71 +30,71 @@ class PackageSpec extends ObjectBehavior
             'suggesters'  => 21,
             'dependents'  => 42,
             'github_stars' => 3086,
-            'github_forks' => 1124
-        ));
+            'github_forks' => 1124,
+        ]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Result\Package');
+        $this->shouldHaveType(Package::class);
     }
 
-    function it_is_a_packagist_result()
+    public function it_is_a_packagist_result()
     {
-        $this->shouldHaveType('Packagist\Api\Result\AbstractResult');
+        $this->shouldHaveType(AbstractResult::class);
     }
 
-    function it_gets_name()
+    public function it_gets_name()
     {
         $this->getName()->shouldReturn('sylius/sylius');
     }
 
-    function it_gets_description()
+    public function it_gets_description()
     {
         $this->getDescription()->shouldReturn('Modern ecommerce for Symfony2');
     }
 
-    function it_gets_time($time)
+    public function it_gets_time($time)
     {
         $this->getTime()->shouldReturn($time);
     }
 
-    function it_gets_maintainers($maintainer)
+    public function it_gets_maintainers($maintainer)
     {
-        $this->getMaintainers()->shouldReturn(array($maintainer));
+        $this->getMaintainers()->shouldReturn([$maintainer]);
     }
 
-    function it_gets_versions($version)
+    public function it_gets_versions($version)
     {
-        $this->getVersions()->shouldReturn(array($version));
+        $this->getVersions()->shouldReturn([$version]);
     }
 
-    function it_gets_type()
+    public function it_gets_type()
     {
         $this->getType()->shouldReturn('library');
     }
 
-    function it_gets_repository()
+    public function it_gets_repository()
     {
         $this->getRepository()->shouldReturn('https://github.com/Sylius/Sylius.git');
     }
 
-    function it_gets_downloads($downloads)
+    public function it_gets_downloads($downloads)
     {
         $this->getDownloads()->shouldReturn($downloads);
     }
 
-    function it_gets_favers()
+    public function it_gets_favers()
     {
         $this->getFavers()->shouldReturn(9999999999);
     }
 
-    function it_gets_abandoned()
+    public function it_gets_abandoned()
     {
         $this->isAbandoned()->shouldReturn(false);
     }
 
-    function it_gets_abandoned_returning_true()
+    public function it_gets_abandoned_returning_true()
     {
         $this->fromArray([
             'name'        => 'typo3/ldap',
@@ -103,7 +104,7 @@ class PackageSpec extends ObjectBehavior
         $this->isAbandoned()->shouldReturn(true);
     }
 
-    function it_gets_replacement_package()
+    public function it_gets_replacement_package()
     {
         $this->fromArray([
             'name'        => 'typo3/ldap',
@@ -113,7 +114,7 @@ class PackageSpec extends ObjectBehavior
         $this->getReplacementPackage()->shouldReturn('neos/ldap');
     }
 
-    function it_gets_replacement_package_returning_null()
+    public function it_gets_replacement_package_returning_null()
     {
         $this->fromArray([
             'name'        => 'typo3/ldap',
@@ -123,22 +124,22 @@ class PackageSpec extends ObjectBehavior
         $this->getReplacementPackage()->shouldReturn(null);
     }
 
-    function it_gets_suggesters()
+    public function it_gets_suggesters()
     {
         $this->getSuggesters()->shouldReturn(21);
     }
 
-    function it_gets_dependents()
+    public function it_gets_dependents()
     {
         $this->getDependents()->shouldReturn(42);
     }
 
-    function it_gets_github_stars()
+    public function it_gets_github_stars()
     {
         $this->getGithubStars()->shouldReturn(3086);
     }
 
-    function it_gets_github_forks()
+    public function it_gets_github_forks()
     {
         $this->getGithubForks()->shouldReturn(1124);
     }

--- a/spec/Packagist/Api/Result/ResultSpec.php
+++ b/spec/Packagist/Api/Result/ResultSpec.php
@@ -1,59 +1,63 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Packagist\Api\Result;
 
+use Packagist\Api\Result\AbstractResult;
+use Packagist\Api\Result\Result;
 use PhpSpec\ObjectBehavior;
 
 class ResultSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
-        $this->fromArray(array(
+        $this->fromArray([
             'name'        => 'sylius/sylius',
             'description' => 'Modern ecommerce for Symfony2',
             'url'         => 'http://sylius.com',
             'downloads'   => 999999999,
             'favers'      => 999999999,
-            'repository'  => 'https://github.com/Sylius/SyliusCartBundle'
-        ));
+            'repository'  => 'https://github.com/Sylius/SyliusCartBundle',
+        ]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
-        $this->shouldHaveType('Packagist\Api\Result\Result');
+        $this->shouldHaveType(Result::class);
     }
 
-    function it_is_a_packagist_result()
+    public function it_is_a_packagist_result()
     {
-        $this->shouldHaveType('Packagist\Api\Result\AbstractResult');
+        $this->shouldHaveType(AbstractResult::class);
     }
 
-    function it_gets_name()
+    public function it_gets_name()
     {
         $this->getName()->shouldReturn('sylius/sylius');
     }
 
-    function it_gets_description()
+    public function it_gets_description()
     {
         $this->getDescription()->shouldReturn('Modern ecommerce for Symfony2');
     }
 
-    function it_gets_url()
+    public function it_gets_url()
     {
         $this->getUrl()->shouldReturn('http://sylius.com');
     }
 
-    function it_gets_downloads()
+    public function it_gets_downloads()
     {
         $this->getDownloads()->shouldReturn(999999999);
     }
 
-    function it_gets_favers()
+    public function it_gets_favers()
     {
         $this->getFavers()->shouldReturn(999999999);
     }
 
-    function it_gets_repository()
+    public function it_gets_repository()
     {
     	$this->getRepository()->shouldReturn('https://github.com/Sylius/SyliusCartBundle');
     }

--- a/src/Packagist/Api/Client.php
+++ b/src/Packagist/Api/Client.php
@@ -167,11 +167,11 @@ class Client
      * Execute the request URL
      *
      * @param string $url
-     * @return StreamInterface
+     * @return string
      */
-    protected function request(string $url): StreamInterface
+    protected function request(string $url): string
     {
-        return $this->httpClient
+        return (string) $this->httpClient
             ->request('get', $url)
             ->getBody();
     }

--- a/src/Packagist/Api/Client.php
+++ b/src/Packagist/Api/Client.php
@@ -33,15 +33,15 @@ class Client
         Factory $resultFactory = null,
         string $packagistUrl = 'https://packagist.org'
     ) {
-		if (null === $httpClient) {
-			$httpClient = new HttpClient();
-		}
+        if (null === $httpClient) {
+            $httpClient = new HttpClient();
+        }
 
-		if (null === $resultFactory) {
-			$resultFactory = new Factory();
-		}
+        if (null === $resultFactory) {
+            $resultFactory = new Factory();
+        }
 
-		$this->httpClient = $httpClient;
+        $this->httpClient = $httpClient;
         $this->resultFactory = $resultFactory;
         $this->packagistUrl = $packagistUrl;
     }
@@ -107,7 +107,7 @@ class Client
     {
         $url = '/packages/list.json';
         if ($filters) {
-            $url .= '?'.http_build_query($filters);
+            $url .= '?' . http_build_query($filters);
         }
 
         return $this->respond($this->url($url));
@@ -163,12 +163,12 @@ class Client
         return $this->create($response);
     }
 
-	/**
-	 * Execute the request URL
-	 *
-	 * @param string $url
-	 * @return StreamInterface
-	 */
+    /**
+     * Execute the request URL
+     *
+     * @param string $url
+     * @return StreamInterface
+     */
     protected function request(string $url): StreamInterface
     {
         return $this->httpClient
@@ -203,7 +203,7 @@ class Client
      * Change the packagist URL
      *
      * @param string $packagistUrl URL
-	 * @return $this
+     * @return $this
      */
     public function setPackagistUrl(string $packagistUrl): self
     {

--- a/src/Packagist/Api/Result/AbstractResult.php
+++ b/src/Packagist/Api/Result/AbstractResult.php
@@ -1,20 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result;
 
-use Doctrine\Common\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 
 abstract class AbstractResult
 {
-    /**
-     * @param array $data
-     */
-    public function fromArray(array $data)
+    public function fromArray(array $data): void
     {
-        $inflector = \class_exists(InflectorFactory::class) ? InflectorFactory::create()->build() : null;
+        $inflector = InflectorFactory::create()->build();
         foreach ($data as $key => $value) {
-            $property = null === $inflector ? Inflector::camelize($key) : $inflector->camelize($key);
+            $property = $inflector->camelize($key);
             $this->$property = $value;
         }
     }

--- a/src/Packagist/Api/Result/Factory.php
+++ b/src/Packagist/Api/Result/Factory.php
@@ -47,7 +47,7 @@ class Factory
 
     /**
      * Create a collection of \Packagist\Api\Result\Result
-	 *
+     *
      * @param array $results
      * @return array
      */
@@ -62,7 +62,7 @@ class Factory
 
     /**
      * Parse array to \Packagist\Api\Result\Result
-	 *
+     *
      * @param array $package
      * @return Package
      */
@@ -108,11 +108,11 @@ class Factory
      * @return AbstractResult $class hydrated
      */
     protected function createResult(string $class, array $data): AbstractResult
-	{
+    {
         $result = new $class();
         if (!$result instanceof AbstractResult) {
-        	throw new InvalidArgumentException('Class must extend AbstractResult');
-		}
+            throw new InvalidArgumentException('Class must extend AbstractResult');
+        }
         $result->fromArray($data);
 
         return $result;

--- a/src/Packagist/Api/Result/Factory.php
+++ b/src/Packagist/Api/Result/Factory.php
@@ -79,14 +79,29 @@ class Factory
         }
 
         foreach ($package['versions'] as $branch => $version) {
+            if (empty($version['name']) && !empty($package['name'])) {
+                $version['name'] = $package['name'];
+            }
+
+            if (isset($version['license'])) {
+                $version['licenses'] = is_array($version['license']) ? $version['license'] : [$version['license']];
+                unset($version['license']);
+            }
+
+            // Cast some potentially null properties to empty strings
+            $version['name'] ??= '';
+            $version['type'] ??= '';
+
             if (isset($version['authors']) && $version['authors']) {
                 foreach ($version['authors'] as $key => $author) {
                     $version['authors'][$key] = $this->createResult(Author::class, $author);
                 }
             }
+
             if ($version['source']) {
                 $version['source'] = $this->createResult(Source::class, $version['source']);
             }
+
             if (isset($version['dist']) && $version['dist']) {
                 $version['dist'] = $this->createResult(Dist::class, $version['dist']);
             }

--- a/src/Packagist/Api/Result/Factory.php
+++ b/src/Packagist/Api/Result/Factory.php
@@ -1,8 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result;
 
 use InvalidArgumentException;
+use Packagist\Api\Result\Package\Author;
+use Packagist\Api\Result\Package\Dist;
+use Packagist\Api\Result\Package\Downloads;
+use Packagist\Api\Result\Package\Maintainer;
+use Packagist\Api\Result\Package\Source;
+use Packagist\Api\Result\Package\Version;
 
 /**
  * Map raw data from website api to has a know type
@@ -39,62 +47,51 @@ class Factory
 
     /**
      * Create a collection of \Packagist\Api\Result\Result
-
+	 *
      * @param array $results
-     *
      * @return array
      */
-    public function createSearchResults(array $results)
+    public function createSearchResults(array $results): array
     {
-        $created = array();
+        $created = [];
         foreach ($results as $key => $result) {
-            $created[$key] = $this->createResult('Packagist\Api\Result\Result', $result);
+            $created[$key] = $this->createResult(Result::class, $result);
         }
-
         return $created;
     }
 
     /**
      * Parse array to \Packagist\Api\Result\Result
-
+	 *
      * @param array $package
-     *
      * @return Package
      */
-    public function createPackageResults(array $package)
+    public function createPackageResults(array $package): Package
     {
-        $created = array();
-
         if (isset($package['maintainers']) && $package['maintainers']) {
             foreach ($package['maintainers'] as $key => $maintainer) {
-                $package['maintainers'][$key] = $this->createResult(
-                    'Packagist\Api\Result\Package\Maintainer',
-                    $maintainer
-                );
+                $package['maintainers'][$key] = $this->createResult(Maintainer::class, $maintainer);
             }
         }
 
         if (isset($package['downloads']) && $package['downloads']) {
-            $package['downloads'] = $this->createResult(
-                'Packagist\Api\Result\Package\Downloads',
-                $package['downloads']
-            );
+            $package['downloads'] = $this->createResult(Downloads::class, $package['downloads']);
         }
 
         foreach ($package['versions'] as $branch => $version) {
             if (isset($version['authors']) && $version['authors']) {
                 foreach ($version['authors'] as $key => $author) {
-                    $version['authors'][$key] = $this->createResult('Packagist\Api\Result\Package\Author', $author);
+                    $version['authors'][$key] = $this->createResult(Author::class, $author);
                 }
             }
             if ($version['source']) {
-                $version['source'] = $this->createResult('Packagist\Api\Result\Package\Source', $version['source']);
+                $version['source'] = $this->createResult(Source::class, $version['source']);
             }
             if (isset($version['dist']) && $version['dist']) {
-                $version['dist'] = $this->createResult('Packagist\Api\Result\Package\Dist', $version['dist']);
+                $version['dist'] = $this->createResult(Dist::class, $version['dist']);
             }
 
-            $package['versions'][$branch] = $this->createResult('Packagist\Api\Result\Package\Version', $version);
+            $package['versions'][$branch] = $this->createResult(Version::class, $version);
         }
 
         $created = new Package();
@@ -104,16 +101,18 @@ class Factory
     }
 
     /**
-     * Dynamically create DataObject of type $class and hydrate
+     * Dynamically create an AbstractResult of type $class and hydrate
      *
      * @param string $class DataObject class
      * @param array  $data Array of data
-     *
-     * @return mixed DataObject $class hydrated
+     * @return AbstractResult $class hydrated
      */
-    protected function createResult($class, array $data)
-    {
+    protected function createResult(string $class, array $data): AbstractResult
+	{
         $result = new $class();
+        if (!$result instanceof AbstractResult) {
+        	throw new InvalidArgumentException('Class must extend AbstractResult');
+		}
         $result->fromArray($data);
 
         return $result;

--- a/src/Packagist/Api/Result/Package.php
+++ b/src/Packagist/Api/Result/Package.php
@@ -1,99 +1,55 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result;
+
+use Packagist\Api\Result\Package\Downloads;
 
 class Package extends AbstractResult
 {
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var string
-     */
-    protected $description;
+    protected string $description;
 
-    /**
-     * @var string
-     */
-    protected $time;
+    protected string $time;
 
-    /**
-     * @var Package\Maintainer[]
-     */
-    protected $maintainers;
+    protected array $maintainers;
 
-    /**
-     * @var Package\Version[]
-     */
-    protected $versions;
+    protected array $versions;
 
-    /**
-     * @var string
-     */
-    protected $type;
+    protected string $type;
 
-    /**
-     * @var string
-     */
-    protected $repository;
+    protected string $repository;
 
-    /**
-     * @var Package\Downloads
-     */
-    protected $downloads;
+    protected Downloads $downloads;
 
-    /**
-     * @var string
-     */
-    protected $favers;
+    protected string $favers;
 
     /**
      * @var bool|string
      */
     protected $abandoned = false;
 
-    /**
-     * @var integer
-     */
-    protected $suggesters = 0;
+    protected int $suggesters = 0;
 
-    /**
-     * @var integer
-     */
-    protected $dependents = 0;
+    protected int $dependents = 0;
 
-    /**
-     * @var integer
-     */
-    protected $githubStars = 0;
+    protected int $githubStars = 0;
 
-    /**
-     * @var integer
-     */
-    protected $githubForks = 0;
+    protected int $githubForks = 0;
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @return string
-     */
-    public function getTime()
+    public function getTime(): string
     {
         return $this->time;
     }
@@ -101,7 +57,7 @@ class Package extends AbstractResult
     /**
      * @return Package\Maintainer[]
      */
-    public function getMaintainers()
+    public function getMaintainers(): array
     {
         return $this->maintainers;
     }
@@ -109,47 +65,32 @@ class Package extends AbstractResult
     /**
      * @return Package\Version[]
      */
-    public function getVersions()
+    public function getVersions(): array
     {
         return $this->versions;
     }
 
-    /**
-     * @return string
-     */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @return string
-     */
-    public function getRepository()
+    public function getRepository(): string
     {
         return $this->repository;
     }
 
-    /**
-     * @return Package\Downloads
-     */
-    public function getDownloads()
+    public function getDownloads(): Downloads
     {
         return $this->downloads;
     }
 
-    /**
-     * @return string
-     */
-    public function getFavers()
+    public function getFavers(): string
     {
         return $this->favers;
     }
 
-    /**
-     * @return bool
-     */
-    public function isAbandoned()
+    public function isAbandoned(): bool
     {
         return (bool) $this->abandoned;
     }
@@ -172,34 +113,22 @@ class Package extends AbstractResult
         return null;
     }
 
-    /**
-     * @return integer
-     */
-    public function getSuggesters()
+    public function getSuggesters(): int
     {
         return $this->suggesters;
     }
 
-    /**
-     * @return integer
-     */
-    public function getDependents()
+    public function getDependents(): int
     {
         return $this->dependents;
     }
 
-    /**
-     * @return integer
-     */
-    public function getGithubStars()
+    public function getGithubStars(): int
     {
         return $this->githubStars;
     }
 
-    /**
-     * @return integer
-     */
-    public function getGithubForks()
+    public function getGithubForks(): int
     {
         return $this->githubForks;
     }

--- a/src/Packagist/Api/Result/Package.php
+++ b/src/Packagist/Api/Result/Package.php
@@ -8,23 +8,23 @@ use Packagist\Api\Result\Package\Downloads;
 
 class Package extends AbstractResult
 {
-    protected string $name;
+    protected string $name = '';
 
-    protected string $description;
+    protected string $description = '';
 
-    protected string $time;
+    protected string $time = '';
 
-    protected array $maintainers;
+    protected array $maintainers = [];
 
-    protected array $versions;
+    protected array $versions = [];
 
-    protected string $type;
+    protected string $type = '';
 
-    protected string $repository;
+    protected string $repository = '';
 
     protected Downloads $downloads;
 
-    protected string $favers;
+    protected int $favers = 0;
 
     /**
      * @var bool|string
@@ -85,7 +85,7 @@ class Package extends AbstractResult
         return $this->downloads;
     }
 
-    public function getFavers(): string
+    public function getFavers(): int
     {
         return $this->favers;
     }

--- a/src/Packagist/Api/Result/Package/Author.php
+++ b/src/Packagist/Api/Result/Package/Author.php
@@ -1,18 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result\Package;
 
 class Author extends Maintainer
 {
-    /**
-     * @var string
-     */
-    protected $role;
+    protected string $role;
 
-    /**
-     * @return string
-     */
-    public function getRole()
+    public function getRole(): string
     {
         return $this->role;
     }

--- a/src/Packagist/Api/Result/Package/Dist.php
+++ b/src/Packagist/Api/Result/Package/Dist.php
@@ -1,57 +1,35 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result\Package;
 
 class Dist extends Source
 {
-    /**
-     * @var string
-     */
-    protected $shasum;
+    protected string $shasum;
 
-    /**
-     * @var string
-     */
-    protected $type;
+    protected string $type;
 
-    /**
-     * @var string
-     */
-    protected $url;
+    protected string $url;
 
-    /**
-     * @var string
-     */
-    protected $reference;
+    protected string $reference;
 
-    /**
-     * @return string
-     */
-    public function getShasum()
+    public function getShasum(): string
     {
         return $this->shasum;
     }
 
-    /**
-     * @return string
-     */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @return string
-     */
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->url;
     }
 
-    /**
-     * @return string
-     */
-    public function getReference()
+    public function getReference(): string
     {
         return $this->reference;
     }

--- a/src/Packagist/Api/Result/Package/Downloads.php
+++ b/src/Packagist/Api/Result/Package/Downloads.php
@@ -1,70 +1,48 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result\Package;
 
 use Packagist\Api\Result\AbstractResult;
 
 class Downloads extends AbstractResult
 {
-    /**
-     * @var integer
-     */
-    protected $total;
+    protected int $total;
 
-    /**
-     * @var integer
-     */
-    protected $monthly;
+    protected int $monthly;
 
-    /**
-     * @var integer
-     */
-    protected $daily;
+    protected int $daily;
 
-    /**
-     * @param integer $total
-     */
-    public function setTotal($total)
+    public function setTotal(int $total): self
     {
         $this->total = $total;
+        return $this;
     }
 
-    /**
-     * @param integer $monthly
-     */
-    public function setMonthly($monthly)
+    public function setMonthly(int $monthly): self
     {
         $this->monthly = $monthly;
+        return $this;
     }
 
-    /**
-     * @param integer $daily
-     */
-    public function setDaily($daily)
+    public function setDaily(int $daily): self
     {
         $this->daily = $daily;
+		return $this;
     }
 
-    /**
-     * @return integer
-     */
-    public function getTotal()
+    public function getTotal(): int
     {
         return $this->total;
     }
 
-    /**
-     * @return integer
-     */
-    public function getMonthly()
+    public function getMonthly(): int
     {
         return $this->monthly;
     }
 
-    /**
-     * @return integer
-     */
-    public function getDaily()
+    public function getDaily(): int
     {
         return $this->daily;
     }

--- a/src/Packagist/Api/Result/Package/Downloads.php
+++ b/src/Packagist/Api/Result/Package/Downloads.php
@@ -29,7 +29,7 @@ class Downloads extends AbstractResult
     public function setDaily(int $daily): self
     {
         $this->daily = $daily;
-		return $this;
+        return $this;
     }
 
     public function getTotal(): int

--- a/src/Packagist/Api/Result/Package/Maintainer.php
+++ b/src/Packagist/Api/Result/Package/Maintainer.php
@@ -1,46 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result\Package;
 
 use Packagist\Api\Result\AbstractResult;
 
 class Maintainer extends AbstractResult
 {
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var string
-     */
-    protected $email;
+    protected string $email;
 
-    /**
-     * @var string
-     */
-    protected $homepage;
+    protected string $homepage;
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->email;
     }
 
-    /**
-     * @return string
-     */
-    public function getHomepage()
+    public function getHomepage(): string
     {
         return $this->homepage;
     }

--- a/src/Packagist/Api/Result/Package/Source.php
+++ b/src/Packagist/Api/Result/Package/Source.php
@@ -1,46 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result\Package;
 
 use Packagist\Api\Result\AbstractResult;
 
 class Source extends AbstractResult
 {
-    /**
-     * @var string
-     */
-    protected $type;
+    protected string $type;
 
-    /**
-     * @var string
-     */
-    protected $url;
+    protected string $url;
 
-    /**
-     * @var string
-     */
-    protected $reference;
+    protected string $reference;
 
-    /**
-     * @return string
-     */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @return string
-     */
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->url;
     }
 
-    /**
-     * @return string
-     */
-    public function getReference()
+    public function getReference(): string
     {
         return $this->reference;
     }

--- a/src/Packagist/Api/Result/Package/Version.php
+++ b/src/Packagist/Api/Result/Package/Version.php
@@ -8,47 +8,47 @@ use Packagist\Api\Result\AbstractResult;
 
 class Version extends AbstractResult
 {
-    protected string $name;
+    protected string $name = '';
 
-    protected string $description;
+    protected string $description = '';
 
-    protected array $keywords;
+    protected array $keywords = [];
 
-    protected string $homepage;
+    protected string $homepage = '';
 
-    protected string $version;
+    protected string $version = '';
 
-    protected string $versionNormalized;
+    protected string $versionNormalized = '';
 
-    protected string $license;
+    protected array $licenses = [];
 
-    protected array $authors;
+    protected array $authors = [];
 
-    protected Source $source;
+    protected ?Source $source;
 
-    protected Dist $dist;
+    protected ?Dist $dist;
 
-    protected string $type;
+    protected string $type = '';
 
-    protected string $time;
+    protected string $time = '';
 
-    protected array $autoload;
+    protected array $autoload = [];
 
-    protected array $extra;
+    protected array $extra = [];
 
-    protected array $require;
+    protected array $require = [];
 
-    protected array $requireDev;
+    protected array $requireDev = [];
 
-    protected string $conflict;
+    protected array $conflict = [];
 
-    protected string $provide;
+    protected array $provide = [];
 
-    protected string $replace;
+    protected array $replace = [];
 
-    protected string $bin;
+    protected array $bin = [];
 
-    protected array $suggest;
+    protected array $suggest = [];
 
     /**
      * @var bool|string
@@ -85,9 +85,9 @@ class Version extends AbstractResult
         return $this->versionNormalized;
     }
 
-    public function getLicense(): string
+    public function getLicenses(): array
     {
-        return $this->license;
+        return $this->licenses;
     }
 
     public function getAuthors(): array
@@ -95,12 +95,12 @@ class Version extends AbstractResult
         return $this->authors;
     }
 
-    public function getSource(): Source
+    public function getSource(): ?Source
     {
         return $this->source;
     }
 
-    public function getDist(): Dist
+    public function getDist(): ?Dist
     {
         return $this->dist;
     }
@@ -135,22 +135,22 @@ class Version extends AbstractResult
         return $this->requireDev;
     }
 
-    public function getConflict(): string
+    public function getConflict(): array
     {
         return $this->conflict;
     }
 
-    public function getProvide(): string
+    public function getProvide(): array
     {
         return $this->provide;
     }
 
-    public function getReplace(): string
+    public function getReplace(): array
     {
         return $this->replace;
     }
 
-    public function getBin(): string
+    public function getBin(): array
     {
         return $this->bin;
     }

--- a/src/Packagist/Api/Result/Package/Version.php
+++ b/src/Packagist/Api/Result/Package/Version.php
@@ -1,293 +1,166 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result\Package;
 
 use Packagist\Api\Result\AbstractResult;
 
 class Version extends AbstractResult
 {
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var string
-     */
-    protected $description;
+    protected string $description;
 
-    /**
-     * @var array
-     */
-    protected $keywords;
+    protected array $keywords;
 
-    /**
-     * @var string
-     */
-    protected $homepage;
+    protected string $homepage;
 
-    /**
-     * @var string
-     */
-    protected $version;
+    protected string $version;
 
-    /**
-     * @var string
-     */
-    protected $versionNormalized;
+    protected string $versionNormalized;
 
-    /**
-     * @var string
-     */
-    protected $license;
+    protected string $license;
 
-    /**
-     * @var array
-     */
-    protected $authors;
+    protected array $authors;
 
-    /**
-     * @var Source
-     */
-    protected $source;
+    protected Source $source;
 
-    /**
-     * @var Dist
-     */
-    protected $dist;
+    protected Dist $dist;
 
-    /**
-     * @var string
-     */
-    protected $type;
+    protected string $type;
 
-    /**
-     * @var string
-     */
-    protected $time;
+    protected string $time;
 
-    /**
-     * @var array
-     */
-    protected $autoload;
+    protected array $autoload;
 
-    /**
-     * @var array
-     */
-    protected $extra;
+    protected array $extra;
 
-    /**
-     * @var array
-     */
-    protected $require;
+    protected array $require;
 
-    /**
-     * @var array
-     */
-    protected $requireDev;
+    protected array $requireDev;
 
-    /**
-     * @var string
-     */
-    protected $conflict;
+    protected string $conflict;
 
-    /**
-     * @var string
-     */
-    protected $provide;
+    protected string $provide;
 
-    /**
-     * @var string
-     */
-    protected $replace;
+    protected string $replace;
 
-    /**
-     * @var string
-     */
-    protected $bin;
+    protected string $bin;
 
-    /**
-     * @var array
-     */
-    protected $suggest;
+    protected array $suggest;
 
     /**
      * @var bool|string
      */
     protected $abandoned = false;
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @return array
-     */
-    public function getKeywords()
+    public function getKeywords(): array
     {
         return $this->keywords;
     }
 
-    /**
-     * @return string
-     */
-    public function getHomepage()
+    public function getHomepage(): string
     {
         return $this->homepage;
     }
 
-    /**
-     * @return string
-     */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }
 
-    /**
-     * @return string
-     */
-    public function getVersionNormalized()
+    public function getVersionNormalized(): string
     {
         return $this->versionNormalized;
     }
 
-    /**
-     * @return string
-     */
-    public function getLicense()
+    public function getLicense(): string
     {
         return $this->license;
     }
 
-    /**
-     * @return array
-     */
-    public function getAuthors()
+    public function getAuthors(): array
     {
         return $this->authors;
     }
 
-    /**
-     * @return Source
-     */
-    public function getSource()
+    public function getSource(): Source
     {
         return $this->source;
     }
 
-    /**
-     * @return Dist
-     */
-    public function getDist()
+    public function getDist(): Dist
     {
         return $this->dist;
     }
 
-    /**
-     * @return string
-     */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @return string
-     */
-    public function getTime()
+    public function getTime(): string
     {
         return $this->time;
     }
 
-    /**
-     * @return array
-     */
-    public function getAutoload()
+    public function getAutoload(): array
     {
         return $this->autoload;
     }
 
-    /**
-     * @return array
-     */
-    public function getExtra()
+    public function getExtra(): array
     {
         return $this->extra;
     }
 
-    /**
-     * @return array
-     */
-    public function getRequire()
+    public function getRequire(): array
     {
         return $this->require;
     }
 
-    /**
-     * @return array
-     */
-    public function getRequireDev()
+    public function getRequireDev(): array
     {
         return $this->requireDev;
     }
 
-    /**
-     * @return string
-     */
-    public function getConflict()
+    public function getConflict(): string
     {
         return $this->conflict;
     }
 
-    /**
-     * @return string
-     */
-    public function getProvide()
+    public function getProvide(): string
     {
         return $this->provide;
     }
 
-    /**
-     * @return string
-     */
-    public function getReplace()
+    public function getReplace(): string
     {
         return $this->replace;
     }
 
-    /**
-     * @return string
-     */
-    public function getBin()
+    public function getBin(): string
     {
         return $this->bin;
     }
 
-    /**
-     * @return array
-     */
-    public function getSuggest()
+    public function getSuggest(): array
     {
         return $this->suggest;
     }
 
-    /**
-     * @return bool
-     */
-    public function isAbandoned()
+    public function isAbandoned(): bool
     {
         return (bool) $this->abandoned;
     }

--- a/src/Packagist/Api/Result/Result.php
+++ b/src/Packagist/Api/Result/Result.php
@@ -1,83 +1,49 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Packagist\Api\Result;
 
 class Result extends AbstractResult
 {
-    /**
-     * @var string
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var string
-     */
-    protected $description;
+    protected string $description;
 
-    /**
-     * @var string
-     */
-    protected $url;
+    protected string $url;
 
-    /**
-     * @var string
-     */
-    protected $downloads;
+    protected int $downloads;
 
-    /**
-     * @var string
-     */
-    protected $favers;
+    protected int $favers;
 
-    /**
-     * @var string
-     */
-    protected $repository;
+    protected string $repository;
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @return string
-     */
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->url;
     }
 
-    /**
-     * @return string
-     */
-    public function getDownloads()
+    public function getDownloads(): int
     {
         return $this->downloads;
     }
 
-    /**
-     * @return string
-     */
-    public function getFavers()
+    public function getFavers(): int
     {
         return $this->favers;
     }
 
-    /**
-     * @return string
-     */
-    public function getRepository()
+    public function getRepository(): string
     {
         return $this->repository;
     }


### PR DESCRIPTION
* Increase minimum PHP version to 7.4
* Remove custom `bin` directory
* Add scalar return types and property types, add strict typing
* Run automated PSR-12 linting
* Update specs to use short array syntax and public function visibility
* Update return types to include default returns for scalars and arrays
* Replace `license` on Version with `licenses` since it can return multiple

This is a breaking change, so will require a 2.0 release of this library. I'll leave this pull request open for a week or two to gather any feedback that may come in before merging.