### PR TITLE
Fix the handling of minified metadata responses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests and linting
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "doctrine/inflector": "^1.0 || ^2.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "composer/metadata-minifier": "^1.0"
 	},
     "require-dev": {
         "phpspec/phpspec": "^6.0 || ^7.0",

--- a/src/Packagist/Api/Result/Factory.php
+++ b/src/Packagist/Api/Result/Factory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Packagist\Api\Result;
 
+use Composer\MetadataMinifier\MetadataMinifier;
 use InvalidArgumentException;
 use Packagist\Api\Result\Package\Author;
 use Packagist\Api\Result\Package\Dist;
@@ -131,19 +132,6 @@ class Factory
             $version['name'] ??= '';
             $version['type'] ??= '';
 
-            if (isset($version['conflict']) && !is_array($version['conflict'])) {
-                unset($version['conflict']);
-            }
-            if (isset($version['suggest']) && !is_array($version['suggest'])) {
-                unset($version['suggest']);
-            }
-            if (isset($version['replace']) && !is_array($version['replace'])) {
-                unset($version['replace']);
-            }
-            if (isset($version['provide']) && !is_array($version['provide'])) {
-                unset($version['provide']);
-            }
-
             if (isset($version['authors']) && $version['authors']) {
                 foreach ($version['authors'] as $key => $author) {
                     // Cast some potentially null properties to empty strings
@@ -198,6 +186,7 @@ class Factory
         $created = [];
 
         foreach ($packages as $name => $package) {
+            $package = MetadataMinifier::expand($package);
             // Create an empty package, only contains versions
             $createdPackage = array(
                 'versions' => [],


### PR DESCRIPTION
This fixes the implementation done in #72, which was not properly expanding minified metadata, and so returning wrong results (and it was adding some unsetting to handle *some* of the minified structure).

This relies on the official MetadataMinifier of Composer, which is available as a dedicated package for such purpose.