### PR TITLE
Mark reference and shasum of dist correctly as nullable

### DIFF
--- a/spec/Packagist/Api/Result/Package/DistSpec.php
+++ b/spec/Packagist/Api/Result/Package/DistSpec.php
@@ -43,4 +43,28 @@ class DistSpec extends ObjectBehavior
     {
         $this->getShasum()->shouldReturn('cb0a489db41707d5df078f1f35e028e04ffd9e8e');
     }
+
+    public function it_can_deal_with_nullable_reference()
+    {
+        $this->fromArray([
+            'type'      => 'git',
+            'url'       => 'https://github.com/Sylius/Sylius.git',
+            'reference' => null,
+            'shasum'    => 'cb0a489db41707d5df078f1f35e028e04ffd9e8e',
+        ]);
+
+        $this->getReference()->shouldReturn(null);
+    }
+
+    public function it_can_deal_with_nullable_shasum()
+    {
+        $this->fromArray([
+            'type'      => 'git',
+            'url'       => 'https://github.com/Sylius/Sylius.git',
+            'reference' => 'cb0a489db41707d5df078f1f35e028e04ffd9e8e',
+            'shasum'    => null,
+        ]);
+
+        $this->getShasum()->shouldReturn(null);
+    }
 }

--- a/src/Packagist/Api/Result/Package/Dist.php
+++ b/src/Packagist/Api/Result/Package/Dist.php
@@ -8,15 +8,15 @@ use Packagist\Api\Result\AbstractResult;
 
 class Dist extends AbstractResult
 {
-    protected string $shasum;
+    protected ?string $shasum;
 
     protected string $type;
 
     protected string $url;
 
-    protected string $reference;
+    protected ?string $reference;
 
-    public function getShasum(): string
+    public function getShasum(): ?string
     {
         return $this->shasum;
     }
@@ -31,7 +31,7 @@ class Dist extends AbstractResult
         return $this->url;
     }
 
-    public function getReference(): string
+    public function getReference(): ?string
     {
         return $this->reference;
     }

--- a/src/Packagist/Api/Result/Package/Dist.php
+++ b/src/Packagist/Api/Result/Package/Dist.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Packagist\Api\Result\Package;
 
-class Dist extends Source
+use Packagist\Api\Result\AbstractResult;
+
+class Dist extends AbstractResult
 {
     protected string $shasum;
 


### PR DESCRIPTION
### Fixed
- In some cases, the `shasum` and `reference` property for the `dist` of a `version` is returned by packagist as `null`. (example: https://packagist.org/packages/roots/wordpress.json). Parsing this result threw a TypeError when trying to set `null` as a `string` during hydration of the `Dist` model.