### PR TITLE
New: Add security advisories endpoint.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,9 @@
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "doctrine/inflector": "^1.0 || ^2.0",
         "ext-json": "*",
-        "composer/metadata-minifier": "^1.0"
-	},
+        "composer/metadata-minifier": "^1.0",
+        "composer/semver": "^1.0|^2.0|^3.0"
+    },
     "require-dev": {
         "phpspec/phpspec": "^6.0 || ^7.0",
         "squizlabs/php_codesniffer": "^3.0"

--- a/examples/advisories.php
+++ b/examples/advisories.php
@@ -1,0 +1,17 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$client = new Packagist\Api\Client();
+
+// Get any advisories for the monolog/monolog package
+$advisories = $client->advisories(['monolog/monolog']);
+var_export($advisories);
+
+// Get any advisories for the monolog/monolog package which were modified after midnight 2022/07/2022.
+$advisories = $client->advisories(['monolog/monolog' => '1.8.1'], 1659052800);
+var_export($advisories);
+
+// Get any advisories for the monolog/monolog package which will affect version 1.8.1 of that package
+$advisories = $client->advisories(['monolog/monolog' => '1.8.1'], null, true);
+var_export($advisories);

--- a/spec/Packagist/Api/Result/Advisory/SourceSpec.php
+++ b/spec/Packagist/Api/Result/Advisory/SourceSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Packagist\Api\Result\Advisory;
+
+use Packagist\Api\Result\Advisory\Source;
+use PhpSpec\ObjectBehavior;
+
+class SourceSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->fromArray([
+            'name' => 'FriendsOfPHP/security-advisories',
+            'remoteId' => 'monolog/monolog/2014-12-29-1.yaml',
+        ]);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(Source::class);
+    }
+
+    public function it_gets_name()
+    {
+        $this->getName()->shouldReturn('FriendsOfPHP/security-advisories');
+    }
+
+    public function it_gets_remote_id()
+    {
+        $this->getRemoteId()->shouldReturn('monolog/monolog/2014-12-29-1.yaml');
+    }
+}

--- a/spec/Packagist/Api/Result/AdvisorySpec.php
+++ b/spec/Packagist/Api/Result/AdvisorySpec.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Packagist\Api\Result;
+
+use Packagist\Api\Result\AbstractResult;
+use Packagist\Api\Result\Advisory;
+use Packagist\Api\Result\Advisory\Source;
+use PhpSpec\ObjectBehavior;
+
+class AdvisorySpec extends ObjectBehavior
+{
+    private $source;
+
+    private function data()
+    {
+        return [
+            'advisoryId' => 'PKSA-dmw8-jd8k-q3c6',
+            'packageName' => 'monolog/monolog',
+            'remoteId' => 'monolog/monolog/2014-12-29-1.yaml',
+            'title' => 'Header injection in NativeMailerHandler',
+            'link' => 'https://github.com/Seldaek/monolog/pull/448#issuecomment-68208704',
+            'cve' => 'test-value',
+            'affectedVersions' => '>=1.8.0,<1.12.0',
+            'sources' => [$this->source],
+            'reportedAt' => '2014-12-29 00:00:00',
+            'composerRepository' => 'https://packagist.org',
+        ];
+    }
+
+    public function let(Source $source)
+    {
+        $this->source = $source;
+        $this->fromArray($this->data());
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(Advisory::class);
+    }
+
+    public function it_is_a_packagist_result()
+    {
+        $this->shouldHaveType(AbstractResult::class);
+    }
+
+    public function it_gets_advisory_id()
+    {
+        $this->getAdvisoryId()->shouldReturn($this->data()['advisoryId']);
+    }
+
+    public function it_gets_package_name()
+    {
+        $this->getPackageName()->shouldReturn($this->data()['packageName']);
+    }
+
+    public function it_gets_remote_id()
+    {
+        $this->getRemoteId()->shouldReturn($this->data()['remoteId']);
+    }
+
+    public function it_gets_title()
+    {
+        $this->getTitle()->shouldReturn($this->data()['title']);
+    }
+
+    public function it_gets_link()
+    {
+        $this->getLink()->shouldReturn($this->data()['link']);
+    }
+
+    public function it_gets_cve()
+    {
+        $this->getCve()->shouldReturn($this->data()['cve']);
+    }
+
+    public function it_gets_affected_versions()
+    {
+        $this->getAffectedVersions()->shouldReturn($this->data()['affectedVersions']);
+    }
+
+    public function it_gets_sources()
+    {
+        $this->getSources()->shouldReturn($this->data()['sources']);
+    }
+
+    public function it_gets_reported_at()
+    {
+        $this->getReportedAt()->shouldReturn($this->data()['reportedAt']);
+    }
+
+    public function it_gets_composer_repository()
+    {
+        $this->getComposerRepository()->shouldReturn($this->data()['composerRepository']);
+    }
+}

--- a/src/Packagist/Api/Result/Advisory.php
+++ b/src/Packagist/Api/Result/Advisory.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Packagist\Api\Result;
+
+use Packagist\Api\Result\AbstractResult;
+use Packagist\Api\Result\Advisory\Source;
+
+class Advisory extends AbstractResult
+{
+    protected string $advisoryId;
+
+    protected string $packageName;
+
+    protected string $remoteId;
+
+    protected string $title;
+
+    protected string $link;
+
+    protected string $cve;
+
+    protected string $affectedVersions;
+
+    /**
+     * @var Source[]
+     */
+    protected array $sources;
+
+    protected string $reportedAt;
+
+    protected string $composerRepository;
+
+    public function getAdvisoryId(): string
+    {
+        return $this->advisoryId;
+    }
+
+    public function getPackageName(): string
+    {
+        return $this->packageName;
+    }
+
+    public function getRemoteId(): string
+    {
+        return $this->remoteId;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getLink(): string
+    {
+        return $this->link;
+    }
+
+    public function getCve(): string
+    {
+        return $this->cve;
+    }
+
+    public function getAffectedVersions(): string
+    {
+        return $this->affectedVersions;
+    }
+
+    /**
+     * @return Source[]
+     */
+    public function getSources(): array
+    {
+        return $this->sources;
+    }
+
+    public function getReportedAt(): string
+    {
+        return $this->reportedAt;
+    }
+
+    public function getComposerRepository(): string
+    {
+        return $this->composerRepository;
+    }
+}

--- a/src/Packagist/Api/Result/Advisory/Source.php
+++ b/src/Packagist/Api/Result/Advisory/Source.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Packagist\Api\Result\Advisory;
+
+use Packagist\Api\Result\AbstractResult;
+
+class Source extends AbstractResult
+{
+    protected string $name;
+
+    protected string $remoteId;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getRemoteId(): string
+    {
+        return $this->remoteId;
+    }
+}


### PR DESCRIPTION
Adds functionality to use the security advisories endpoint on the packagist api: https://packagist.org/apidoc#list-security-advisories

Draft because I want to know if this is an acceptable approach before I start adding tests.
