### PR TITLE
Fix access error in Maintainer

### DIFF
--- a/src/Packagist/Api/Result/Package/Maintainer.php
+++ b/src/Packagist/Api/Result/Package/Maintainer.php
@@ -8,11 +8,11 @@ use Packagist\Api\Result\AbstractResult;
 
 class Maintainer extends AbstractResult
 {
-    protected string $name;
+    protected string $name = '';
 
-    protected string $email;
+    protected string $email = '';
 
-    protected string $homepage;
+    protected string $homepage = '';
 
     public function getName(): string
     {


### PR DESCRIPTION
Since PHP 8.x I get the error `"$field must not be accessed before initialization"` when iterating the maintainers and accessing their properties. Not all 3 fields are always set.