### PR TITLE
Unknown properties from the Packagist API are no longer set on AbstractResult

### DIFF
--- a/spec/Packagist/Api/Result/PackageSpec.php
+++ b/spec/Packagist/Api/Result/PackageSpec.php
@@ -29,6 +29,8 @@ class PackageSpec extends ObjectBehavior
             'dependents'  => 42,
             'github_stars' => 3086,
             'github_forks' => 1124,
+            // A dynamic property, causes deprecation warnings in PHP 8.2+ and is now ignored in AbstractResult
+            'supports_cheese' => true,
         ]);
     }
 

--- a/src/Packagist/Api/Result/AbstractResult.php
+++ b/src/Packagist/Api/Result/AbstractResult.php
@@ -16,6 +16,9 @@ abstract class AbstractResult
             if (null === $value && !$this->isNullable($property)) {
                 continue;
             }
+            if (!property_exists($this, $property)) {
+                continue;
+            }
             $this->$property = $value;
         }
     }


### PR DESCRIPTION
If you find a property is missing, please file a bug report on GitHub and we can get it added.

Fixes #92