### PR TITLE
Replace Guzzle with generic PSR18 discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,19 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "doctrine/inflector": "^1.0 || ^2.0",
         "ext-json": "*",
         "composer/metadata-minifier": "^1.0",
-        "composer/semver": "^1.0|^2.0|^3.0"
+        "composer/semver": "^1.0|^2.0|^3.0",
+        "php-http/discovery": "^1.12",
+        "php-http/client-common": "^2.3",
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory-implementation": "^1.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^6.0 || ^7.0",
-        "squizlabs/php_codesniffer": "^3.0"
+        "squizlabs/php_codesniffer": "^3.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -41,5 +45,10 @@
     "scripts": {
         "lint": "vendor/bin/phpcs --standard=PSR12 src/",
         "test": "vendor/bin/phpspec run -f pretty"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }


### PR DESCRIPTION
Resolves #91
Note that this would most likely need to be a new major release, as it changes the method signature of several methods which were previously relying on a Guzzle-specific options array.

This works well locally, but I have never used phpspec before and I don't know how to update the tests. Can someone with some knowledge of phpspec please give me some guidance?

All of the `ClientSpec` tests are failing - the error message and trace is:

> ```
> Packagist/Api/Client                                                              
>   29  - it search for packages
>       exception [err:TypeError("Double\GuzzleHttp\Client\P1::sendRequest(): Return value must be of type Psr\Http\Message\ResponseInterface, null returned")] has been thrown.
>        0 vendor/phpspec/prophecy/src/Prophecy/Doubler/Generator/ClassCreator.php(44) : eval()'d code:25
>          throw new PhpSpec\Exception\ErrorException("Double\GuzzleHttp\Client\...")
>        1 vendor/symfony/console/Application.php:1096
>          Symfony\Component\Console\Command\Command->run()
>        2 vendor/symfony/console/Application.php:324
>          Symfony\Component\Console\Application->doRunCommand()
>        3 vendor/phpspec/phpspec/src/PhpSpec/Console/Application.php:91
>          Symfony\Component\Console\Application->doRun()
>        4 vendor/phpspec/phpspec/bin/phpspec:25
>          Symfony\Component\Console\Application->run()
>        5 vendor/phpspec/phpspec/bin/phpspec:27
>          {closure}()
>        6 vendor/bin/phpspec:120
>          include("/home/gsartorelli/dump/te...")
> ```
