### PR TITLE
Add PHP 8.3 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
 
     name: PHP ${{ matrix.php-versions }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set PHP version
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
https://github.com/phpspec/phpspec/issues/1450 notes that phpspec 7.5.0 supports PHP 8.3, so we can now test for it. Closes #95.

Also updates actions/checkout version, just to be up to date